### PR TITLE
Partially reimplement credential reading from aws.

### DIFF
--- a/src/Mismi/S3/Control.hs
+++ b/src/Mismi/S3/Control.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RankNTypes #-}
 module Mismi.S3.Control (
     S3Action
   , runS3WithDefaults
@@ -6,13 +7,21 @@ module Mismi.S3.Control (
   ) where
 
 import qualified Aws
+import           Aws.Aws
+import           Aws.Core
 import qualified Aws.S3 as S3
 
-import           Control.Monad.Reader
+import           Data.Text as T
+
+import           Control.Monad.Catch
+import           Control.Monad.Reader hiding (forM)
+import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource (ResourceT)
 
 import           Network.HTTP.Client (Manager)
 import           Network.HTTP.Conduit (withManager)
+
+import           P
 
 import           System.IO
 
@@ -22,9 +31,37 @@ type S3Action = ReaderT (Aws.Configuration, S3.S3Configuration Aws.NormalQuery, 
 
 runS3WithDefaults :: S3Action a -> IO a
 runS3WithDefaults action = do
-  Aws.baseConfiguration >>= \cfg -> runS3WithCfg cfg action
+  baseConfiguration' >>= \cfg -> runS3WithCfg cfg action
 
 runS3WithCfg :: Aws.Configuration -> S3Action a -> IO a
 runS3WithCfg cfg action =
   let scfg = Aws.defServiceConfig
   in withManager (\m -> runReaderT action (cfg, scfg, m))
+
+-- Snip from Aws library, this works around an issue where it throws exceptions if you don't
+-- have a $HOME set (i.e. no shell) - this happens when you are running things as a daemon
+-- where it should just fallback gracefully to env vars or instance-metadata.
+
+baseConfiguration' :: (MonadCatch io, MonadIO io) => io Configuration
+baseConfiguration' = liftIO $
+    loadCredentialsDefault' >>=
+      maybe (throwM $ NoCredentialsException "could not locate aws credentials") (\cr' -> return Configuration {
+                      timeInfo = Timestamp
+                    , credentials = cr'
+                    , logger = defaultLog Warning
+                    })
+
+loadCredentialsDefault' :: (MonadCatch io, MonadIO io)  => io (Maybe Credentials)
+loadCredentialsDefault' = do
+  file <- liftM Just credentialsDefaultFile `catchIOError` (const . return) Nothing
+  loadCredentialsFromEnvOrFileOrInstanceMetadata' file credentialsDefaultKey
+
+loadCredentialsFromEnvOrFileOrInstanceMetadata' :: MonadIO io => Maybe FilePath -> T.Text -> io (Maybe Credentials)
+loadCredentialsFromEnvOrFileOrInstanceMetadata' file key =
+  loadCredentialsFromEnv >>=
+    maybe (loadCredentialsFromInstanceMetadata) (return . return) >>=
+    maybe (loadCredentialsFromFile' key file) (return . return)
+
+loadCredentialsFromFile' :: MonadIO io => T.Text -> Maybe FilePath -> io (Maybe Credentials)
+loadCredentialsFromFile' key =
+ maybe (return Nothing) (flip loadCredentialsFromFile key)


### PR DESCRIPTION
This prevents exceptions (for a non related auth mechanisms) exploding
before the valid mechanisms can even be checked.

Specifically this was done to work aroun an issue where getHomeDirectory
is called in a non-safe way in the internals of the library. When running
as a daemon, $HOME is not set, and causes this to explode in an way that
I would consider not pleasant.
