### PR TITLE
Making (</>) more robust

### DIFF
--- a/src/Mismi/S3/Data.hs
+++ b/src/Mismi/S3/Data.hs
@@ -51,7 +51,10 @@ instance Show Address where
     "Address (" <> show b <> ") (" <> show k <> ")"
 
 (</>) :: Key -> Key -> Key
-(</>) (Key p1) (Key p2) = Key $ p1 <> "/" <> p2
+(</>) (Key p1) (Key p2) =
+  if  ("/" `T.isSuffixOf` p1 || p1 == "" || "/" `T.isPrefixOf` p2)
+    then Key $ p1 <> p2
+    else Key $ p1 <> "/" <> p2
 
 withKey :: (Key -> Key) -> Address -> Address
 withKey f (Address b k) = Address b $ f k

--- a/test/Test/Mismi/Arbitrary.hs
+++ b/test/Test/Mismi/Arbitrary.hs
@@ -22,7 +22,7 @@ instance Arbitrary Key where
   -- https://github.com/ambiata/vee/issues/7
   arbitrary =
     let genPath = elements ["happy", "sad", ".", ":", "-"]
-        path = T.dropWhileEnd ('/' ==) . T.take 256 . T.intercalate "/" <$> listOf1 (T.intercalate "" <$> listOf1 genPath)
+        path = T.take 256 . T.intercalate "/" <$> listOf1 (T.intercalate "" <$> listOf1 genPath)
     in (Key . append "tests/") <$> path
 
 instance Arbitrary QueueName where

--- a/test/Test/Mismi/S3/Commands.hs
+++ b/test/Test/Mismi/S3/Commands.hs
@@ -156,9 +156,8 @@ prop_list t = monadicIO $
 prop_dirname :: Address -> Text -> Property
 prop_dirname a t =
   let k = Key t in
-  T.all (/= '/') t ==>
-    dirname (key a </> k) === key a
-
+  T.all (/= '/') t==>
+    dirname (key a </> k) === Key (dropWhileEnd ('/' ==) . unKey . key $ a)
 
 return []
 tests :: IO Bool

--- a/test/Test/Mismi/S3/Data.hs
+++ b/test/Test/Mismi/S3/Data.hs
@@ -6,6 +6,7 @@ module Test.Mismi.S3.Data where
 import           Data.Text as T
 
 import           Mismi.S3.Data
+import           Orphanarium.Corpus
 
 import           Test.Mismi
 import           Test.Mismi.S3 ()
@@ -13,6 +14,13 @@ import           Test.Mismi.S3 ()
 prop_append :: Key -> Key -> Property
 prop_append p1 p2 =
   T.count "//" (unKey (p1 </> p2)) === 0
+
+prop_appendEdge :: Property
+prop_appendEdge = forAll ((,) <$> elements muppets <*> elements southpark) $ \(m, s) -> conjoin [
+    (Key (m <> "/") </> Key s) === (Key $ m <> "/" <> s)
+  , (Key m </> Key ("/" <> s)) === (Key $ m <> "/" <> s)
+  , (Key m </> Key s) === (Key $ m <> "/" <> s)
+  ]
 
 prop_parse :: Address -> Property
 prop_parse a =


### PR DESCRIPTION
Adding some basic validation around `</>`. Basically just don't add a separator if the first key has a trailing `/` or if the second key as leading `/`

Fixes #40 
