### PR TITLE
Bump response timeouts to 60 seconds

### DIFF
--- a/mismi-core/src/Mismi/Control/Amazonka.hs
+++ b/mismi-core/src/Mismi/Control/Amazonka.hs
@@ -45,6 +45,7 @@ import           Mismi.Environment
 import           Network.AWS.Data
 
 import           Network.HTTP.Client (Manager)
+import           Network.HTTP.Client.Internal (mResponseTimeout)
 import           Network.HTTP.Types.Status
 
 import           P
@@ -105,7 +106,8 @@ runAWSDefaultRegion a = do
 
 runAWSWithEnv :: Env -> AWS a -> EitherT AWSError IO a
 runAWSWithEnv e a =
-  EitherT . fmap (first AWSRunError) $ runAWST e a
+  let e' = over envManager (\m -> m { mResponseTimeout = Just 60000000 }) e
+  in EitherT . fmap (first AWSRunError) $ runAWST e' a
 
 -- Unfortunately amazonka doesn't expose this function in the current version
 getEnvWithManager :: Region -> AWS.Credentials -> Manager -> IO Env

--- a/mismi-s3/src/Mismi/S3/Control.hs
+++ b/mismi-s3/src/Mismi/S3/Control.hs
@@ -40,6 +40,7 @@ import           Mismi.Control
 import           Mismi.S3.Internal
 
 import           Network.HTTP.Client (HttpException, Manager)
+import           Network.HTTP.Client.Internal (mResponseTimeout)
 import           Network.HTTP.Conduit (withManager)
 
 import qualified Network.AWS.S3.Types as AWS
@@ -62,7 +63,7 @@ runS3WithRegion r action =
 
 runS3WithCfg :: Aws.Configuration -> Region -> S3Action a -> IO a
 runS3WithCfg cfg r action =
-  withManager (\m -> runS3WithManager cfg r m action)
+  withManager (\m -> runS3WithManager cfg r m { mResponseTimeout = Just 60000000 } action)
 
 runS3WithManager :: Aws.Configuration -> Region -> Manager -> S3Action a -> ResourceT IO a
 runS3WithManager cfg r m action =


### PR DESCRIPTION
Currently trying to perf test `download` with/without shared manager and still getting a shit load of retries. Opening anyway for now.
