### PR TITLE
Explicit credentials should never touch network.

### DIFF
--- a/.projectile
+++ b/.projectile
@@ -1,0 +1,5 @@
+-/*/dist
+-/*/.cabal-sandbox
+-/lib
+-/.cabal-sandbox
+-/dist


### PR DESCRIPTION
There are a couple of important issues here, the
most important being that having explicit creds
should never trigger a discover that may touch
something that can't be accessed, a secondary
issue is that expiry with explicit STS creds
isn't really useful in this context (it is more
for metadata service case).