### PR TITLE
Do not ignore "retry times" parameter

### DIFF
--- a/mismi-s3/src/Mismi/S3/Aws/Default.hs
+++ b/mismi-s3/src/Mismi/S3/Aws/Default.hs
@@ -31,7 +31,6 @@ import           Mismi.S3.Aws.Data
 import qualified Mismi.S3.Aws.Commands as M
 import qualified Mismi.S3.Commands as A
 import           Mismi.S3.Data
-import           Mismi.S3.Internal
 
 import           P
 
@@ -94,4 +93,4 @@ sync m s d = retryAction 3 . M.sync m s d
 
 
 retryAction :: Int -> S3Action a -> S3Action a
-retryAction r = A.retryAWSAction (retryWithBackoff r)
+retryAction = A.retryAWSAction

--- a/mismi-s3/src/Mismi/S3/Default.hs
+++ b/mismi-s3/src/Mismi/S3/Default.hs
@@ -39,7 +39,6 @@ import           Data.Conduit
 import           Mismi.S3.Commands as X (AWS, MultipartUpload, muUploadId, retryAWSAction)
 import qualified Mismi.S3.Commands as A
 import           Mismi.S3.Data
-import           Mismi.S3.Internal
 
 import           P
 
@@ -123,4 +122,4 @@ syncWithMode :: SyncMode -> Address -> Address -> Int -> AWS ()
 syncWithMode m s d = retryAction 3 . A.syncWithMode m s d
 
 retryAction :: Int -> AWS a -> AWS a
-retryAction r = retryAWSAction (retryWithBackoff r)
+retryAction = retryAWSAction

--- a/mismi-s3/src/Mismi/S3/Internal.hs
+++ b/mismi-s3/src/Mismi/S3/Internal.hs
@@ -8,7 +8,6 @@ module Mismi.S3.Internal (
   , sinkChanWithDelay
   , waitForNResults
   , withFileSafe
-  , retryWithBackoff
   ) where
 
 import           Control.Concurrent
@@ -86,8 +85,3 @@ withFileSafe f1 run = do
   onException
     (run f2 >>= \a -> liftIO $ whenM (doesFileExist f2) (renameFile f2 f1) >> pure a)
     (liftIO $ removeFile f2)
-
-retryWithBackoff :: Int -> RetryPolicy
-retryWithBackoff i =
-  capDelay 60000000 {- 60 seconds -} $
-  limitRetries i <> exponentialBackoff 100000 {- 100 milliseconds -}

--- a/mismi-s3/test/Test/Mismi/Amazonka.hs
+++ b/mismi-s3/test/Test/Mismi/Amazonka.hs
@@ -79,4 +79,4 @@ withAWSToken t f = do
   awsBracket_ (pure ()) ((retryAction . listRecursively) a >>= mapM_ delete >> delete a) (retryAction $ f a)
 
 retryAction :: AWS a -> AWS a
-retryAction = retryAWSAction (retryWithBackoff 5)
+retryAction = retryAWSAction 5

--- a/mismi-sqs/src/Mismi/SQS/Aws/Commands.hs
+++ b/mismi-sqs/src/Mismi/SQS/Aws/Commands.hs
@@ -96,7 +96,7 @@ toMessageAttribute = \case
   "ApproximateFirstReceiveTimestamp" -> pure ApproximateFirstReceiveTimestamp
   "ApproximateReceiveCount" -> pure ApproximateReceiveCount
   "SenderId" -> pure SenderId
-  "SentTimestamp" -> pure SenderId
+  "SentTimestamp" -> pure SentTimestamp
   u -> fail $ "Unsupported MessageAttribute: " <> unpack u
 
 toAttributes :: M.HashMap A.QueueAttributeName Text -> SQSAction [(MessageAttribute, T.Text)]


### PR DESCRIPTION
New `amazonka` no longer accepts `RetryPolicy` providing instead its own `Retry` type (low-level) and `envRetryCheck` function in `Env`. During the conversion `RetryPolicy` parameter was simply ignored and as a result the default parameter (defined in amazonka per service) was used to limit the number of retries.