### PR TITLE
Catch metadata http errors

### DIFF
--- a/mismi-ec2/mismi-ec2.cabal
+++ b/mismi-ec2/mismi-ec2.cabal
@@ -21,6 +21,7 @@ library
                      , amazonka-ec2                    == 1.1.*
                      , bytestring                      == 0.10.*
                      , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*
                      , http-conduit                    == 2.1.5.*
                      , mtl                             >= 2.2.1      && < 2.3

--- a/mismi-ec2/src/Mismi/EC2/Metadata.hs
+++ b/mismi-ec2/src/Mismi/EC2/Metadata.hs
@@ -8,7 +8,7 @@ module Mismi.EC2.Metadata (
   , metadataErrorRender
   ) where
 
-import           Control.Monad.Except
+import           Control.Monad.Catch
 import           Control.Monad.Trans.Either
 
 import           Data.ByteString.Char8      as BS
@@ -34,12 +34,12 @@ data MetadataError =
 fetchMetadata :: AWS.Metadata -> EitherT MetadataError IO ByteString
 fetchMetadata  metadata' = EitherT $ do
   m <- managerWithDefaultTimeout
-  fmap (mapLeft MetadataHttpError) . runExceptT $ metadata m metadata'
+  fmap (mapLeft MetadataHttpError) . try $ metadata m metadata'
 
 fetchUserData :: EitherT MetadataError IO (Maybe M.UserData)
 fetchUserData = EitherT $ do
   m <- managerWithDefaultTimeout
-  fmap (mapLeft MetadataHttpError) . runExceptT $ userdata m >>=
+  fmap (mapLeft MetadataHttpError) . try $ userdata m >>=
      pure . fmap (M.UserData . T.decodeUtf8)
 
 fetchInstanceId :: EitherT MetadataError IO M.InstanceId


### PR DESCRIPTION
/cc @EduardSergeev A good example of code that breaks due to exceptions without the compiler giving any warning. :(