### PR TITLE
Exposing upload control flow as value

### DIFF
--- a/mismi-s3/main/s3.hs
+++ b/mismi-s3/main/s3.hs
@@ -120,7 +120,7 @@ runC c = do
     Delete a ->
       delete a
     Write a t w ->
-      writeWithMode w a t
+      writeWithModeOrFail w a t
     Read a ->
       read a >>= \md -> liftIO $ maybe exitFailure (pure . unpack) md >>= putStrLn
     Size a ->

--- a/mismi-s3/main/s3.hs
+++ b/mismi-s3/main/s3.hs
@@ -89,7 +89,7 @@ runK k = do
   e <- orDie envErrorRender . EitherT $ discoverAWSEnv
   orDie errorRender . runAWST e $ case k of
     Uploadk s d ->
-      upload s d
+      uploadOrFail s d
     Downloadk s d ->
       download s d
     Sizek a ->
@@ -108,7 +108,7 @@ runC c = do
     List a rq ->
       rec (list a) (listRecursively a) rq >>= liftIO . mapM_ (putStrLn . unpack . addressToText)
     Upload s d ->
-      upload s d
+      uploadOrFail s d
     Download s d ->
       download s d
     Copy s d ->

--- a/mismi-s3/src/Mismi/S3/Data.hs
+++ b/mismi-s3/src/Mismi/S3/Data.hs
@@ -11,6 +11,8 @@ module Mismi.S3.Data (
   , Upload (..)
   , S3Error (..)
   , ErrorType (..)
+  , UploadResult (..)
+  , UploadError (..)
   , (</>)
   , combineKey
   , dirname
@@ -79,6 +81,15 @@ renderErrorType e = case e of
     "download"
   CopyError ->
     "copy"
+
+
+data UploadResult =
+    UploadOk
+  | UploadError UploadError
+
+data UploadError =
+    UploadSourceMissing FilePath
+  | UploadDestinationExists Address
 
 -- |
 -- Describes the semantics for destructive operation that may result in overwritten files.

--- a/mismi-s3/src/Mismi/S3/Data.hs
+++ b/mismi-s3/src/Mismi/S3/Data.hs
@@ -13,6 +13,7 @@ module Mismi.S3.Data (
   , ErrorType (..)
   , UploadResult (..)
   , UploadError (..)
+  , WriteResult (..)
   , (</>)
   , combineKey
   , dirname
@@ -82,6 +83,9 @@ renderErrorType e = case e of
   CopyError ->
     "copy"
 
+data WriteResult =
+    WriteOk
+  | WriteDestinationExists Address
 
 data UploadResult =
     UploadOk

--- a/mismi-s3/src/Mismi/S3/Data.hs
+++ b/mismi-s3/src/Mismi/S3/Data.hs
@@ -86,14 +86,17 @@ renderErrorType e = case e of
 data WriteResult =
     WriteOk
   | WriteDestinationExists Address
+  deriving (Eq, Show)
 
 data UploadResult =
     UploadOk
   | UploadError UploadError
+  deriving (Eq, Show)
 
 data UploadError =
     UploadSourceMissing FilePath
   | UploadDestinationExists Address
+  deriving (Eq, Show)
 
 -- |
 -- Describes the semantics for destructive operation that may result in overwritten files.

--- a/mismi-s3/src/Mismi/S3/Default.hs
+++ b/mismi-s3/src/Mismi/S3/Default.hs
@@ -18,7 +18,9 @@ module Mismi.S3.Default (
   , uploadWithMode
   , uploadWithModeOrFail
   , write
+  , writeOrFail
   , writeWithMode
+  , writeWithModeOrFail
   , copy
   , copyWithMode
   , move
@@ -101,11 +103,17 @@ uploadWithMode m f = retryAction 3 . A.uploadWithMode m f
 uploadWithModeOrFail :: WriteMode -> FilePath -> Address -> AWS ()
 uploadWithModeOrFail m f = retryAction 3 . A.uploadWithModeOrFail m f
 
-write :: Address -> Text -> AWS ()
+write :: Address -> Text -> AWS WriteResult
 write a = retryAction 5 . A.write a
 
-writeWithMode :: WriteMode -> Address -> Text -> AWS ()
+writeOrFail :: Address -> Text -> AWS ()
+writeOrFail a = retryAction 5 . A.writeOrFail a
+
+writeWithMode :: WriteMode -> Address -> Text -> AWS WriteResult
 writeWithMode m a = retryAction 5 . A.writeWithMode m a
+
+writeWithModeOrFail :: WriteMode -> Address -> Text -> AWS ()
+writeWithModeOrFail m a = retryAction 5 . A.writeWithModeOrFail m a
 
 download :: Address -> FilePath -> AWS ()
 download a = retryAction 5 . A.download a

--- a/mismi-s3/src/Mismi/S3/Default.hs
+++ b/mismi-s3/src/Mismi/S3/Default.hs
@@ -14,7 +14,9 @@ module Mismi.S3.Default (
   , downloadWithMode
   , multipartDownload
   , upload
+  , uploadOrFail
   , uploadWithMode
+  , uploadWithModeOrFail
   , write
   , writeWithMode
   , copy
@@ -87,11 +89,17 @@ getObjectsRecursively = retryAction 5 . A.getObjectsRecursively
 abortMultipart :: Bucket -> MultipartUpload -> AWS ()
 abortMultipart b = retryAction 5 . A.abortMultipart b
 
-upload :: FilePath -> Address -> AWS ()
+upload :: FilePath -> Address -> AWS UploadResult
 upload f = retryAction 3 . A.upload f
 
-uploadWithMode :: WriteMode -> FilePath -> Address -> AWS ()
+uploadOrFail :: FilePath -> Address -> AWS ()
+uploadOrFail f = retryAction 3 . A.uploadOrFail f
+
+uploadWithMode :: WriteMode -> FilePath -> Address -> AWS UploadResult
 uploadWithMode m f = retryAction 3 . A.uploadWithMode m f
+
+uploadWithModeOrFail :: WriteMode -> FilePath -> Address -> AWS ()
+uploadWithModeOrFail m f = retryAction 3 . A.uploadWithModeOrFail m f
 
 write :: Address -> Text -> AWS ()
 write a = retryAction 5 . A.write a

--- a/mismi-s3/test/Test/IO/Mismi/S3/Commands.hs
+++ b/mismi-s3/test/Test/IO/Mismi/S3/Commands.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE PackageImports #-}
 module Test.IO.Mismi.S3.Commands where
 
 import           Control.Concurrent
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 
-import           Crypto.Hash
+import "cryptohash" Crypto.Hash
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS

--- a/mismi-s3/test/Test/IO/Mismi/S3/Commands.hs
+++ b/mismi-s3/test/Test/IO/Mismi/S3/Commands.hs
@@ -41,7 +41,7 @@ import           Test.QuickCheck.Instances ()
 
 prop_exists :: Property
 prop_exists = withAWS $ \a -> do
-  write a ""
+  writeOrFail a ""
   e <- exists a
   pure $ e === True
 
@@ -69,19 +69,19 @@ prop_getObjects_empty = withAWS $ \a -> do
 prop_getObjectsR :: Text -> Key -> Key -> Property
 prop_getObjectsR t p1 p2 = p1 /= p2 ==> withAWS $ \root -> do
   let keys = [p1, p2 </> p1, p2 </> p2]
-  forM_ keys $ \k -> write (withKey (</> k) root) t
+  forM_ keys $ \k -> writeOrFail (withKey (</> k) root) t
   objs <- getObjectsRecursively root
   pure $ on (===) L.sort ((^. C.oKey . to toText) <$> objs) (unKey . (</>) (key root) <$> keys)
 
 prop_getObjs :: Property
 prop_getObjs = forAll ((,) <$> elements muppets <*> choose (1000, 1500)) $ \(m, n) -> withAWS $ \a -> A.once $ do
-  forM_ [1..n] $ \n' -> write (withKey(</> Key (m <> pack (show n'))) a) ""
+  forM_ [1..n] $ \n' -> writeOrFail (withKey(</> Key (m <> pack (show n'))) a) ""
   r' <- list a
   pure $ length r' === n
 
 prop_size :: Text -> Property
 prop_size t = withAWS $ \a -> do
-  write a t
+  writeOrFail a t
   i <- getSize a
   pure $ i === (Just . BS.length $ T.encodeUtf8 t)
 
@@ -92,7 +92,7 @@ prop_size_failure = withAWS $ \a -> do
 
 prop_copy :: Text -> Property
 prop_copy t = withAWS' $ \a b -> do
-  write a t
+  writeOrFail a t
   copy a b
   a' <- read a
   b' <- read b
@@ -100,22 +100,22 @@ prop_copy t = withAWS' $ \a b -> do
 
 prop_copy_overwrite :: Text -> Text -> Property
 prop_copy_overwrite t t' = withAWS' $ \a b -> do
-  write a t
-  write b t'
+  writeOrFail a t
+  writeOrFail b t'
   copyWithMode Overwrite a b
   b' <- read b
   pure $ b' === Just t
 
 prop_copy_fail :: Text -> Property
 prop_copy_fail t = withAWS' $ \a b -> do
-  write a t
-  write b t
+  writeOrFail a t
+  writeOrFail b t
   (False <$ copyWithMode Fail a b) `catchAll` (const . pure $ True)
 
 prop_move :: Text -> Token -> Property
 prop_move t d' = withAWS $ \s ->
   withToken d' $ \d -> do
-    write s t
+    writeOrFail s t
     move s d
     es <- exists s
     ed <- exists d
@@ -147,7 +147,8 @@ prop_upload_fail d l = withLocalAWS $ \p a -> do
   liftIO . D.createDirectoryIfMissing True $ F.takeDirectory t
   liftIO $ T.writeFile t d
   uploadWithModeOrFail Fail t a
-  (False <$ uploadWithModeOrFail Fail t a) `catchAll` (const . pure $ True)
+  r <- uploadWithMode Fail t a
+  pure $ r === (UploadError (UploadDestinationExists a))
 
 prop_upload :: Text -> LocalPath -> Property
 prop_upload d l = withLocalAWS $ \p a -> do
@@ -211,21 +212,21 @@ findMultipart uploadId m =
 
 prop_list :: Property
 prop_list = forAll ((,) <$> elements muppets <*> elements southpark) $ \(m, s) -> withAWS $ \a -> do
-  write (withKey(</> Key m) a) ""
-  write (withKey(</> (Key s </> Key m)) a) ""
+  writeOrFail (withKey(</> Key m) a) ""
+  writeOrFail (withKey(</> (Key s </> Key m)) a) ""
   r' <- list a
   pure $ (Just . Key <$> [m, s <> "/"]) === (removeCommonPrefix a <$> r')
 
 prop_listObjects :: Property
 prop_listObjects = forAll ((,) <$> elements muppets <*> elements southpark) $ \(m, s) -> withAWS $ \a -> do
-  write (withKey(</> Key m) a) ""
-  write (withKey(</> (Key s </> Key m)) a) ""
+  writeOrFail (withKey(</> Key m) a) ""
+  writeOrFail (withKey(</> (Key s </> Key m)) a) ""
   (p, k) <- listObjects a
   pure $ ([Just . Key $ s <> "/"], [Just $ Key m]) === (removeCommonPrefix a <$> p, removeCommonPrefix a <$> k)
 
 prop_list_recursively :: Property
 prop_list_recursively = withAWS $ \a -> do
-  write a ""
+  writeOrFail a ""
   r' <- listRecursively (a { key = dirname $ key a })
   pure $ a `elem` r'
 
@@ -233,7 +234,7 @@ prop_list_recursively = withAWS $ \a -> do
 prop_download :: Text -> LocalPath -> Property
 prop_download d l = withLocalAWS $ \p a -> do
   let t = p F.</> localPath  l
-  write a d
+  writeOrFail a d
   download a t
   res <- liftIO $ T.readFile t
   pure $ res === d
@@ -264,9 +265,9 @@ prop_download_multipart = forAll ((,,) <$> arbitrary <*> elements colours <*> el
 prop_write_download_overwrite :: Text -> Text -> LocalPath -> Property
 prop_write_download_overwrite old new l = withLocalAWS $ \p a -> do
   let t = p F.</> localPath  l
-  write a old
+  writeOrFail a old
   downloadWithMode Fail a t
-  writeWithMode Overwrite a new
+  writeWithModeOrFail Overwrite a new
   downloadWithMode Overwrite a t
   r <- liftIO $ T.readFile t
   pure $ r === new
@@ -274,15 +275,14 @@ prop_write_download_overwrite old new l = withLocalAWS $ \p a -> do
 prop_write_download_fail :: Text -> Text -> LocalPath -> Property
 prop_write_download_fail old new l = withLocalAWS $ \p a -> do
   let t = p F.</> localPath  l
-  write a old
+  writeOrFail a old
   downloadWithMode Fail a t
-  writeWithMode Overwrite a new
+  writeWithModeOrFail Overwrite a new
   (False <$ downloadWithMode Fail a t) `catchAll` (const . pure $ True)
-
 
 prop_delete :: WriteMode -> Property
 prop_delete w = withAWS $ \a -> do
-  writeWithMode w a ""
+  writeWithModeOrFail w a ""
   x <- exists a
   delete a
   y <- exists a
@@ -292,22 +292,22 @@ prop_delete_empty :: Property
 prop_delete_empty = withAWS $ \a ->
   (True <$ delete a) `catchAll` (const . pure $ False)
 
-
 prop_read_write :: Text -> Property
 prop_read_write d = withAWS $ \a -> do
-  write a d
+  writeOrFail a d
   r <- read a
   pure $ r === Just d
 
 prop_write_failure :: Text -> Property
 prop_write_failure d = withAWS $ \a -> do
-  write a d
-  (False <$ write a d) `catchAll` (const . pure $ True)
+  writeOrFail a d
+  r <- write a d
+  pure $ r === WriteDestinationExists a
 
 prop_write_overwrite :: UniquePair Text -> Property
 prop_write_overwrite (UniquePair x y) = withAWS $ \a -> do
-  writeWithMode Fail a x
-  writeWithMode Overwrite a y
+  writeWithModeOrFail Fail a x
+  writeWithModeOrFail Overwrite a y
   r <- read a
   pure $ r === pure y
 
@@ -316,7 +316,7 @@ prop_write_overwrite (UniquePair x y) = withAWS $ \a -> do
 --
 prop_write_nonexisting :: WriteMode -> Text -> Property
 prop_write_nonexisting w t = withAWS $ \a -> do
-  writeWithMode w a t
+  writeWithModeOrFail w a t
   r <- read a
   pure $ r === pure t
 


### PR DESCRIPTION
Basically this change is to allow consumers of `mismi` to choose how to evaluate errors for upload. The situation I am trying to solve is where I want to use upload, but I need to add context around failure cases. Having a ghc exception bubble up stating "Destination file already exists for s3://foo/bar" is not useful or interest to me. So the options without this are:
 - I have as a consumer are to either call `exists` and have some process where I fail myself before calling (this is obviously bad because of an extra call; and a race between the exists calls)
 - or the option is too have a `catch` around the upload call and then add context with my own error message (preference not to control flow via `catch`)

Considerations:
Thought about exposing this as `EitherT UploadError AWS ()` - However this just doesn't seem useful either as it becomes quite difficult to work with

Open to a discussion about this. Its probably part of a larger discussion about values / error types / exceptions (not that we have to solve everything now, but maybe a first step).

@charleso @EduardSergeev @markhibberd 