### PR TITLE
Define Show for EnvError

### DIFF
--- a/mismi-core/src/Mismi/Environment.hs
+++ b/mismi-core/src/Mismi/Environment.hs
@@ -42,6 +42,9 @@ data EnvError =
     MissingRegion
   deriving (Eq, Typeable)
 
+instance Show EnvError where
+  show = T.unpack . envErrorRender
+
 getRegionFromEnv :: (MonadIO m, MonadThrow m) => m (Maybe Region)
 getRegionFromEnv = do
   mr <- liftIO $ lookupEnv "AWS_DEFAULT_REGION"


### PR DESCRIPTION
So it can be included in other errors with `deriving Show`