### PR TITLE
Added a paragraph about s3 as a command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,28 @@ runS3WithDefaults action =
     let c = cfg { logger = defaultLog Aws.Aws.Debug }
     runS3WithCfg c Sydney action
 ```
+
+### Command line
+
+The `mismi-s3` module provides a command-line tool for interacting with s3 resources
+```
+cd mismi-s3
+./cabal build
+alias s3="dist/build/s3/s3"
+
+s3 --help
+
+Available commands:
+  upload                   Upload a file to s3.
+  download                 Download a file from s3.
+  copy                     Copy a file from an S3 address to another S3 address.
+  move                     Move an S3 address to another S3 address
+  exists                   Check if an address exists.
+  delete                   Delete an address.
+  write                    Write to an address.
+  read                     Read from an address.
+  cat                      Stream data from an address.
+  size                     Get the size of an address.
+  sync                     Sync between two prefixes.
+  ls                       Stream a recursively list of objects on a prefix
+```


### PR DESCRIPTION
I would add the `arm` command to install it if `arm` wasn't private. Sometimes I wish we had Ambiata-specific doc on public repositories...