### PR TITLE
Add env discovery with retry capability

### DIFF
--- a/mismi-core/mismi-core.cabal
+++ b/mismi-core/mismi-core.cabal
@@ -14,11 +14,10 @@ description:           mismi.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , ambiata-p
-                     , ambiata-x-exception
-                     , template-haskell
                      , amazonka                        == 1.3.2
                      , amazonka-core                   == 1.3.2
+                     , ambiata-p
+                     , ambiata-x-exception
                      , bifunctors                      == 4.2.*
                      , bytestring                      == 0.10.*
                      , either                          == 4.3.*
@@ -26,13 +25,15 @@ library
                      , http-client                     == 0.4.18.*
                      , http-conduit                    == 2.1.5.*
                      , http-types                      == 0.8.*
+                     , lens                            >= 4.8        && < 4.10
                      , mtl                             >= 2.1       && < 2.3
                      , profunctors                     >= 4         && < 5
                      , resourcet                       == 1.1.*
+                     , retry                           == 0.6.*
+                     , template-haskell
                      , text                            == 1.2.*
                      , time                            == 1.4.*
                      , transformers                    >= 0.3        && < 0.5
-                     , lens                            >= 4.8        && < 4.10
 
   ghc-options:
                        -Wall


### PR DESCRIPTION
Inadvertently retrying on `MissingFileError`s is pretty annoying; I might submit an amazonka patch so we can do this more granularly.

Also, not sure if we should default to retrying here and expose an alternative function which fails fast?

/cc @nhibberd @EduardSergeev 