### PR TITLE
Adding new sub project stubs

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,18 +1,14 @@
 #!/bin/sh -exu
 
-$(dirname $0)/ci.common
+PROJECT=${1:?"'ci' requires a single argument, specifying the mismi sub-project."}
+$(dirname $0)/ci.common $PROJECT
 
-VERSION=$(cat $(dirname $0)/../mismi-s3/dist/build/autogen/version.txt)
-aws s3 --region=ap-southeast-2 cp mismi-s3/dist/build/s3/s3 s3://ambiata-dist/s3/linux/x86_64/$VERSION/s3-$VERSION
+cd $PROJECT
+cabal haddock --hoogle
 
-MODULES=$(ls mismi-*/*.cabal)
+aws s3 --region=ap-southeast-2 cp --recursive dist/doc/html/ambiata-$SUBMODULE/ s3://ambiata-doc/ambiata-$SUBMODULE-haddock/$VERSION
 
-for x in $MODULES; do
-    (
-        SUBMODULE=$(dirname $x | xargs basename)
-        cd $SUBMODULE
-        cabal haddock --hoogle
-
-        aws s3 --region=ap-southeast-2 cp --recursive dist/doc/html/ambiata-$SUBMODULE/ s3://ambiata-doc/ambiata-$SUBMODULE-haddock/$VERSION
-    )
-done
+if [ $PROJECT = "mismi-s3" ] ; then
+    VERSION=$(cat $(dirname $0)/../mismi-s3/dist/build/autogen/version.txt)
+    aws s3 --region=ap-southeast-2 cp mismi-s3/dist/build/s3/s3 s3://ambiata-dist/s3/linux/x86_64/$VERSION/s3-$VERSION
+fi

--- a/bin/ci.branches
+++ b/bin/ci.branches
@@ -1,6 +1,9 @@
 #!/bin/sh -exu
 
-$(dirname $0)/ci.common
+PROJECT=${1:?"'ci.branches' requires a single argument, specifying the mismi sub-project."}
+$(dirname $0)/ci.common $PROJECT
 
-VERSION=$(cat $(dirname $0)/../mismi-s3/dist/build/autogen/version.txt)
-aws s3 --region=ap-southeast-2 cp mismi-s3/dist/build/s3/s3 s3://ambiata-dist-branches/s3/linux/x86_64/$VERSION/s3-$VERSION
+if [ $PROJECT = "mismi-s3" ] ; then
+    VERSION=$(cat $(dirname $0)/../mismi-s3/dist/build/autogen/version.txt)
+    aws s3 --region=ap-southeast-2 cp mismi-s3/dist/build/s3/s3 s3://ambiata-dist-branches/s3/linux/x86_64/$VERSION/s3-$VERSION
+fi

--- a/bin/ci.cabal
+++ b/bin/ci.cabal
@@ -1,5 +1,7 @@
 #!/bin/sh -exu
 
+PROJECT=${1:?"'ci.cabal' requires a single argument, specifying the mismi sub-project."}
+
 export LC_COLLATE=en_US.UTF-8
 export LANG=en_US.UTF-8
 
@@ -7,23 +9,17 @@ git submodule init
 git submodule sync
 git submodule update
 
-MODULES=$(ls mismi-*/*.cabal)
+cd $PROJECT
 
-for x in $MODULES; do
-    (
-        cd $(dirname $x)
+cabal sandbox delete
 
-        cabal sandbox delete
+./cabal update
+./cabal build
+cabal install
 
-        ./cabal update
-        ./cabal build
-        cabal install
-
-        (
-            cd test && \
-                cabal sandbox init --sandbox ../.cabal-sandbox && \
-                cabal configure && \
-                cabal install
-        ) || exit $?
-    )
-done
+(
+    cd test && \
+    cabal sandbox init --sandbox ../.cabal-sandbox && \
+    cabal configure && \
+    cabal install
+) || exit $?

--- a/bin/ci.common
+++ b/bin/ci.common
@@ -1,5 +1,7 @@
 #!/bin/sh -exu
 
+PROJECT=${1:?"'ci.common' requires a single argument, specifying the mismi sub-project."}
+
 export LC_COLLATE=en_US.UTF-8
 export LANG=en_US.UTF-8
 
@@ -7,13 +9,8 @@ git submodule init
 git submodule sync
 git submodule update
 
-MODULES=$(ls mismi-*/*.cabal)
+cd $PROJECT
 
-for x in $MODULES; do
-    (
-        cd $(dirname $x)
-        ./cabal update || exit $?
-        ./cabal build || exit $?
-        ./cabal test  --log=/dev/stdout || exit $?
-    )
-done
+./cabal update || exit $?
+./cabal build || exit $?
+./cabal test  --log=/dev/stdout || exit $?

--- a/bin/ci.reliability
+++ b/bin/ci.reliability
@@ -1,6 +1,8 @@
 #!/bin/sh -exu
 
+PROJECT=${1:?"'ci.common' requires a single argument, specifying the mismi sub-project."}
+
 export TEST_RELIABILITY_SIZE=2500
 export TEST_RELIABILITY_SUCCESS=5
 
-$(dirname $0)/ci.common
+$(dirname $0)/ci.common $PROJECT

--- a/mismi-autoscaling/.ghci
+++ b/mismi-autoscaling/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-autoscaling/LICENSE
+++ b/mismi-autoscaling/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-autoscaling/cabal
+++ b/mismi-autoscaling/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/mismi-autoscaling/mismi-autoscaling.cabal
+++ b/mismi-autoscaling/mismi-autoscaling.cabal
@@ -1,0 +1,51 @@
+name:                  ambiata-mismi-autoscaling
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-autoscaling.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , amazonka                        == 1.3.2.1
+                     , amazonka-core                   == 1.3.2
+                     , amazonka-autoscaling            == 1.3.2
+                     , bytestring                      == 0.10.*
+                     , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
+                     , http-client                     == 0.4.18.*
+                     , http-conduit                    == 2.1.5.*
+                     , mtl                             >= 2.2.1      && < 2.3
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3.1      && < 0.5
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Mismi.Autoscaling
+                       Mismi.Autoscaling.Amazonka
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-mismi-core
+                     , ambiata-mismi-autoscaling
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-autoscaling/mismi-autoscaling.submodules
+++ b/mismi-autoscaling/mismi-autoscaling.submodules
@@ -1,0 +1,8 @@
+lib/disorder/disorder-core
+lib/disorder/disorder-corpus
+lib/p
+lib/x/x-conduit
+lib/x/x-exception
+lib/x/x-optparse
+mismi-core
+mismi-core/test

--- a/mismi-autoscaling/src/Mismi/Autoscaling.hs
+++ b/mismi-autoscaling/src/Mismi/Autoscaling.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.Autoscaling (
+  ) where

--- a/mismi-autoscaling/src/Mismi/Autoscaling/Amazonka.hs
+++ b/mismi-autoscaling/src/Mismi/Autoscaling/Amazonka.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.Autoscaling.Amazonka (
+    module AWS
+  ) where
+
+import           Mismi.Amazonka as AWS
+
+import           Network.AWS.AutoScaling as AWS

--- a/mismi-autoscaling/test/mismi-autoscaling-test.cabal
+++ b/mismi-autoscaling/test/mismi-autoscaling-test.cabal
@@ -1,0 +1,11 @@
+name:                  ambiata-mismi-ec2-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-mismi-autoscaling
+
+  exposed-modules:

--- a/mismi-autoscaling/test/test.hs
+++ b/mismi-autoscaling/test/test.hs
@@ -1,0 +1,7 @@
+import           Disorder.Core.Main
+
+
+main :: IO ()
+main =
+  disorderMain [
+    ]

--- a/mismi-cloudwatch/.ghci
+++ b/mismi-cloudwatch/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-cloudwatch/LICENSE
+++ b/mismi-cloudwatch/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-cloudwatch/cabal
+++ b/mismi-cloudwatch/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/mismi-cloudwatch/mismi-cloudwatch.cabal
+++ b/mismi-cloudwatch/mismi-cloudwatch.cabal
@@ -1,0 +1,51 @@
+name:                  ambiata-mismi-cloudwatch
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-cloudwatch.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , amazonka                        == 1.3.2.1
+                     , amazonka-core                   == 1.3.2
+                     , amazonka-cloudwatch             == 1.3.2
+                     , bytestring                      == 0.10.*
+                     , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
+                     , http-client                     == 0.4.18.*
+                     , http-conduit                    == 2.1.5.*
+                     , mtl                             >= 2.2.1      && < 2.3
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3.1      && < 0.5
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Mismi.Cloudwatch
+                       Mismi.Cloudwatch.Amazonka
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-mismi-core
+                     , ambiata-mismi-cloudwatch
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-cloudwatch/mismi-cloudwatch.submodules
+++ b/mismi-cloudwatch/mismi-cloudwatch.submodules
@@ -1,0 +1,8 @@
+lib/disorder/disorder-core
+lib/disorder/disorder-corpus
+lib/p
+lib/x/x-conduit
+lib/x/x-exception
+lib/x/x-optparse
+mismi-core
+mismi-core/test

--- a/mismi-cloudwatch/src/Mismi/Cloudwatch.hs
+++ b/mismi-cloudwatch/src/Mismi/Cloudwatch.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.Cloudwatch (
+  ) where

--- a/mismi-cloudwatch/src/Mismi/Cloudwatch/Amazonka.hs
+++ b/mismi-cloudwatch/src/Mismi/Cloudwatch/Amazonka.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.Cloudwatch.Amazonka (
+    module AWS
+  ) where
+
+import           Network.AWS.CloudWatch as AWS

--- a/mismi-cloudwatch/test/mismi-cloudwatch-test.cabal
+++ b/mismi-cloudwatch/test/mismi-cloudwatch-test.cabal
@@ -1,0 +1,11 @@
+name:                  ambiata-mismi-cloudwatch-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-mismi-cloudwatch
+
+  exposed-modules:

--- a/mismi-cloudwatch/test/test.hs
+++ b/mismi-cloudwatch/test/test.hs
@@ -1,0 +1,7 @@
+import           Disorder.Core.Main
+
+
+main :: IO ()
+main =
+  disorderMain [
+    ]

--- a/mismi-core/src/Mismi/Control.hs
+++ b/mismi-core/src/Mismi/Control.hs
@@ -4,6 +4,10 @@
 module Mismi.Control (
     A.AWS
   , A.Error
+  , A.AccessKey
+  , A.SecretKey
+  , A.SessionToken
+  , A.Region (..)
   , runAWS
   , rawRunAWS
   , runAWST

--- a/mismi-ec2/mismi-ec2.cabal
+++ b/mismi-ec2/mismi-ec2.cabal
@@ -36,6 +36,7 @@ library
 
   exposed-modules:
                        Mismi.EC2
+                       Mismi.EC2.Amazonka
                        Mismi.EC2.Data
                        Mismi.EC2.Metadata
 

--- a/mismi-ec2/src/Mismi/EC2/Amazonka.hs
+++ b/mismi-ec2/src/Mismi/EC2/Amazonka.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.EC2.Amazonka (
+    module AWS
+  ) where
+
+import           Network.AWS.EC2 as AWS

--- a/mismi-iam/.ghci
+++ b/mismi-iam/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-iam/LICENSE
+++ b/mismi-iam/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-iam/cabal
+++ b/mismi-iam/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/mismi-iam/mismi-iam.cabal
+++ b/mismi-iam/mismi-iam.cabal
@@ -1,0 +1,51 @@
+name:                  ambiata-mismi-iam
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-iam.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , amazonka                        == 1.3.2.1
+                     , amazonka-core                   == 1.3.2
+                     , amazonka-iam                    == 1.3.2
+                     , bytestring                      == 0.10.*
+                     , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
+                     , http-client                     == 0.4.18.*
+                     , http-conduit                    == 2.1.5.*
+                     , mtl                             >= 2.2.1      && < 2.3
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3.1      && < 0.5
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Mismi.IAM
+                       Mismi.IAM.Amazonka
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-mismi-core
+                     , ambiata-mismi-iam
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-iam/mismi-iam.submodules
+++ b/mismi-iam/mismi-iam.submodules
@@ -1,0 +1,8 @@
+lib/disorder/disorder-core
+lib/disorder/disorder-corpus
+lib/p
+lib/x/x-conduit
+lib/x/x-exception
+lib/x/x-optparse
+mismi-core
+mismi-core/test

--- a/mismi-iam/src/Mismi/IAM.hs
+++ b/mismi-iam/src/Mismi/IAM.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.IAM (
+  ) where

--- a/mismi-iam/src/Mismi/IAM/Amazonka.hs
+++ b/mismi-iam/src/Mismi/IAM/Amazonka.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.IAM.Amazonka (
+    module AWS
+  ) where
+
+import           Network.AWS.IAM as AWS

--- a/mismi-iam/test/mismi-iam-test.cabal
+++ b/mismi-iam/test/mismi-iam-test.cabal
@@ -1,0 +1,11 @@
+name:                  ambiata-mismi-iam-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-mismi-iam
+
+  exposed-modules:

--- a/mismi-iam/test/test.hs
+++ b/mismi-iam/test/test.hs
@@ -1,0 +1,7 @@
+import           Disorder.Core.Main
+
+
+main :: IO ()
+main =
+  disorderMain [
+    ]

--- a/mismi-rds/.ghci
+++ b/mismi-rds/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-rds/LICENSE
+++ b/mismi-rds/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-rds/cabal
+++ b/mismi-rds/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/mismi-rds/mismi-rds.cabal
+++ b/mismi-rds/mismi-rds.cabal
@@ -1,0 +1,51 @@
+name:                  ambiata-mismi-rds
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-rds.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , amazonka                        == 1.3.2.1
+                     , amazonka-core                   == 1.3.2
+                     , amazonka-rds                    == 1.3.2
+                     , bytestring                      == 0.10.*
+                     , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
+                     , http-client                     == 0.4.18.*
+                     , http-conduit                    == 2.1.5.*
+                     , mtl                             >= 2.2.1      && < 2.3
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3.1      && < 0.5
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Mismi.RDS
+                       Mismi.RDS.Amazonka
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-mismi-core
+                     , ambiata-mismi-rds
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-rds/mismi-rds.submodules
+++ b/mismi-rds/mismi-rds.submodules
@@ -1,0 +1,8 @@
+lib/disorder/disorder-core
+lib/disorder/disorder-corpus
+lib/p
+lib/x/x-conduit
+lib/x/x-exception
+lib/x/x-optparse
+mismi-core
+mismi-core/test

--- a/mismi-rds/src/Mismi/RDS.hs
+++ b/mismi-rds/src/Mismi/RDS.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.RDS (
+  ) where

--- a/mismi-rds/src/Mismi/RDS/Amazonka.hs
+++ b/mismi-rds/src/Mismi/RDS/Amazonka.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.RDS.Amazonka (
+    module AWS
+  ) where
+
+import           Network.AWS.RDS as AWS

--- a/mismi-rds/test/mismi-rds-test.cabal
+++ b/mismi-rds/test/mismi-rds-test.cabal
@@ -1,0 +1,11 @@
+name:                  ambiata-mismi-ec2-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-mismi-rds
+
+  exposed-modules:

--- a/mismi-rds/test/test.hs
+++ b/mismi-rds/test/test.hs
@@ -1,0 +1,7 @@
+import           Disorder.Core.Main
+
+
+main :: IO ()
+main =
+  disorderMain [
+    ]

--- a/mismi-sts/.ghci
+++ b/mismi-sts/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-sts/LICENSE
+++ b/mismi-sts/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-sts/cabal
+++ b/mismi-sts/cabal
@@ -1,0 +1,1 @@
+../framework/cabal

--- a/mismi-sts/mismi-sts.cabal
+++ b/mismi-sts/mismi-sts.cabal
@@ -1,0 +1,51 @@
+name:                  ambiata-mismi-sts
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-sts.
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , amazonka                        == 1.3.2.1
+                     , amazonka-core                   == 1.3.2
+                     , amazonka-sts                    == 1.3.2
+                     , bytestring                      == 0.10.*
+                     , either                          == 4.3.*
+                     , exceptions                      == 0.8.*
+                     , http-client                     == 0.4.18.*
+                     , http-conduit                    == 2.1.5.*
+                     , mtl                             >= 2.2.1      && < 2.3
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3.1      && < 0.5
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Mismi.STS
+                       Mismi.STS.Amazonka
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-mismi-core
+                     , ambiata-mismi-sts
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-sts/mismi-sts.submodules
+++ b/mismi-sts/mismi-sts.submodules
@@ -1,0 +1,8 @@
+lib/disorder/disorder-core
+lib/disorder/disorder-corpus
+lib/p
+lib/x/x-conduit
+lib/x/x-exception
+lib/x/x-optparse
+mismi-core
+mismi-core/test

--- a/mismi-sts/src/Mismi/STS.hs
+++ b/mismi-sts/src/Mismi/STS.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.STS (
+  ) where

--- a/mismi-sts/src/Mismi/STS/Amazonka.hs
+++ b/mismi-sts/src/Mismi/STS/Amazonka.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+module Mismi.STS.Amazonka (
+    module AWS
+  ) where
+
+import           Network.AWS.STS as AWS

--- a/mismi-sts/test/mismi-sts-test.cabal
+++ b/mismi-sts/test/mismi-sts-test.cabal
@@ -1,0 +1,11 @@
+name:                  ambiata-mismi-sts-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base
+                     , ambiata-mismi-sts
+
+  exposed-modules:

--- a/mismi-sts/test/test.hs
+++ b/mismi-sts/test/test.hs
@@ -1,0 +1,7 @@
+import           Disorder.Core.Main
+
+
+main :: IO ()
+main =
+  disorderMain [
+    ]


### PR DESCRIPTION
Basic mismi subproject's for the amazon services currently in use with separate `amazonka` exports. This should allow us to transition all of our amazonka dependent code upstream back to mismi, and at a minimum remove all direct amazonka dependencies upstream.