### PR TITLE
Allow the debug mode to be used with tests

### DIFF
--- a/mismi-core/test/Test/Mismi.hs
+++ b/mismi-core/test/Test/Mismi.hs
@@ -11,7 +11,6 @@ import           Control.Monad.Trans.Either
 import           Disorder.Core.IO
 
 import           Mismi
-import           Mismi.Amazonka (newEnv, Credentials (..))
 
 import           P
 
@@ -29,5 +28,5 @@ testAWS =
 runAWSDefaultRegion :: AWS a -> IO a
 runAWSDefaultRegion a = do
   r <- eitherT (const $ pure Sydney) pure getRegionFromEnv
-  e <- newEnv r Discover
+  e <- discoverAWSEnvWithRegion r
   eitherT throwM pure $ runAWS e a


### PR DESCRIPTION
@charleso follow-up from #218, it turns out that the env with the debugging logger was not wired in for tests.