### PR TITLE
Add `findSecurityGroupByName` function

### DIFF
--- a/mismi-ec2/mismi-ec2.cabal
+++ b/mismi-ec2/mismi-ec2.cabal
@@ -24,6 +24,7 @@ library
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*
                      , http-conduit                    == 2.1.5.*
+                     , lens                            >= 4.8        && < 4.10
                      , mtl                             >= 2.2.1      && < 2.3
                      , text                            == 1.2.*
                      , transformers                    >= 0.3.1      && < 0.5
@@ -37,6 +38,7 @@ library
   exposed-modules:
                        Mismi.EC2
                        Mismi.EC2.Amazonka
+                       Mismi.EC2.Commands
                        Mismi.EC2.Config.Virtualization
                        Mismi.EC2.Data
                        Mismi.EC2.Metadata
@@ -50,6 +52,21 @@ test-suite test
                      , ambiata-disorder-core
                      , ambiata-p
                      , ambiata-mismi-core
+                     , ambiata-mismi-ec2
+                     , QuickCheck                      == 2.7.*
+                     , quickcheck-instances            == 0.3.*
+
+
+test-suite test-io
+  type:                exitcode-stdio-1.0
+  main-is:             test-io.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-p
+                     , ambiata-mismi-core
+                     , ambiata-mismi-core-test
                      , ambiata-mismi-ec2
                      , QuickCheck                      == 2.7.*
                      , quickcheck-instances            == 0.3.*

--- a/mismi-ec2/src/Mismi/EC2.hs
+++ b/mismi-ec2/src/Mismi/EC2.hs
@@ -2,6 +2,6 @@ module Mismi.EC2 (
     module X
   ) where
 
+import           Mismi.EC2.Commands as X
 import           Mismi.EC2.Config.Virtualization as X
-import           Mismi.EC2.Data as X
 import           Mismi.EC2.Metadata as X

--- a/mismi-ec2/src/Mismi/EC2/Commands.hs
+++ b/mismi-ec2/src/Mismi/EC2/Commands.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude  #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Mismi.EC2.Commands (
+    module X
+  , findSecurityGroupByName
+  ) where
+
+import           Mismi.Amazonka
+import           Mismi.EC2.Data as X
+
+import           Mismi.EC2.Amazonka
+
+import           P
+
+
+findSecurityGroupByName :: SecurityGroupName -> AWS (Maybe SecurityGroupId)
+findSecurityGroupByName (SecurityGroupName n) = do
+  r <- send $ describeSecurityGroups & dsgsFilters .~ [filter' "group-name" & fValues .~ [n]]
+  return . fmap (SecurityGroupId . view sgGroupId) . listToMaybe . view dsgrsSecurityGroups $ r

--- a/mismi-ec2/src/Mismi/EC2/Data.hs
+++ b/mismi-ec2/src/Mismi/EC2/Data.hs
@@ -7,6 +7,9 @@ module Mismi.EC2.Data (
   , renderVirtualization
   , renderVirtualizationAws
   , parseVirtualization
+
+  , SecurityGroupName(..)
+  , SecurityGroupId(..)
   ) where
 
 import           Data.Text
@@ -52,3 +55,14 @@ renderVirtualizationAws v =
       "hvm"
     Paravirtual ->
       "paravirtual"
+
+
+newtype SecurityGroupName =
+  SecurityGroupName {
+      securityGroupName :: Text
+    } deriving (Eq, Show)
+
+newtype SecurityGroupId =
+  SecurityGroupId {
+      securityGroupId :: Text
+    } deriving (Eq, Show)

--- a/mismi-ec2/test/Test/IO/Mismi/EC2/Arbitrary.hs
+++ b/mismi-ec2/test/Test/IO/Mismi/EC2/Arbitrary.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.IO.Mismi.EC2.Arbitrary where
+
+import           Mismi.EC2.Data
+
+import           P
+
+import           Test.QuickCheck
+
+instance Arbitrary VirtualizationType where
+  arbitrary =
+    elements [HVM, Paravirtual]
+
+instance Arbitrary SecurityGroupName where
+  arbitrary =
+    elements . fmap SecurityGroupName $ [
+      "default"
+    , "test.hub.db"
+    ]

--- a/mismi-ec2/test/Test/IO/Mismi/EC2/Commands.hs
+++ b/mismi-ec2/test/Test/IO/Mismi/EC2/Commands.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Test.IO.Mismi.EC2.Commands where
+
+import           Data.Maybe
+
+import           Mismi.EC2.Commands
+
+import           P
+
+import           System.IO (IO)
+
+import           Test.IO.Mismi.EC2.Arbitrary ()
+import           Test.Mismi
+import           Test.QuickCheck
+
+
+prop_findSecurityGroupByName_found :: SecurityGroupName -> Property
+prop_findSecurityGroupByName_found sg = testAWS $ do
+  mid <- findSecurityGroupByName sg
+  return $ isJust mid
+
+prop_findSecurityGroupByName_not_found :: Property
+prop_findSecurityGroupByName_not_found = testAWS $ do
+  mid <- findSecurityGroupByName (SecurityGroupName "not-found")
+  return $ mid === Nothing
+
+
+return []
+tests :: IO Bool
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 2 })

--- a/mismi-ec2/test/mismi-ec2-test.cabal
+++ b/mismi-ec2/test/mismi-ec2-test.cabal
@@ -15,4 +15,5 @@ library
 
 
   exposed-modules:
+                     Test.IO.Mismi.EC2.Arbitrary
                      Test.Mismi.EC2.Arbitrary

--- a/mismi-ec2/test/test-io.hs
+++ b/mismi-ec2/test/test-io.hs
@@ -1,0 +1,9 @@
+import           Disorder.Core.Main
+
+import           Test.IO.Mismi.EC2.Commands
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.IO.Mismi.EC2.Commands.tests
+    ]


### PR DESCRIPTION
VPC security group ID lookup by group name

Implements https://github.com/ambiata/mismi/issues/249