### PR TITLE
Upgrade amazonka to 1.3.4 for KMS key deletion

### DIFF
--- a/mismi-autoscaling/mismi-autoscaling.cabal
+++ b/mismi-autoscaling/mismi-autoscaling.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-autoscaling            == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-autoscaling            == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-cloudwatch-logs/mismi-cloudwatch-logs.cabal
+++ b/mismi-cloudwatch-logs/mismi-cloudwatch-logs.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-cloudwatch-logs        == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-cloudwatch-logs        == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-cloudwatch/mismi-cloudwatch.cabal
+++ b/mismi-cloudwatch/mismi-cloudwatch.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-cloudwatch             == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-cloudwatch             == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-core/mismi-core.cabal
+++ b/mismi-core/mismi-core.cabal
@@ -14,8 +14,8 @@ description:           mismi.
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
                      , ambiata-p
                      , ambiata-x-eithert
                      , ambiata-x-exception

--- a/mismi-core/test/mismi-core-test.cabal
+++ b/mismi-core/test/mismi-core-test.cabal
@@ -6,8 +6,8 @@ build-type:            Simple
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-mismi-core

--- a/mismi-ec2/mismi-ec2.cabal
+++ b/mismi-ec2/mismi-ec2.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-ec2                    == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-ec2                    == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-iam/mismi-iam.cabal
+++ b/mismi-iam/mismi-iam.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-iam                    == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-iam                    == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-rds/mismi-rds.cabal
+++ b/mismi-rds/mismi-rds.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-rds                    == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-rds                    == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*

--- a/mismi-s3/mismi-s3.cabal
+++ b/mismi-s3/mismi-s3.cabal
@@ -21,9 +21,9 @@ library
                      , ambiata-x-exception
                      , ambiata-twine
                      , template-haskell
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-s3                     == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-s3                     == 1.3.4
                      , bytestring                      == 0.10.*
                      , bifunctors                      == 4.2.*
                      , conduit                         == 1.2.*

--- a/mismi-s3/test/mismi-s3-test.cabal
+++ b/mismi-s3/test/mismi-s3-test.cabal
@@ -6,9 +6,9 @@ build-type:            Simple
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-s3                     == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-s3                     == 1.3.4
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-mismi-core

--- a/mismi-sqs/mismi-sqs.cabal
+++ b/mismi-sqs/mismi-sqs.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , template-haskell
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-sqs                    == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-sqs                    == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      >= 0.6        && < 0.9
                      , http-client                     == 0.4.18.*

--- a/mismi-sqs/test/mismi-sqs-test.cabal
+++ b/mismi-sqs/test/mismi-sqs-test.cabal
@@ -6,8 +6,8 @@ build-type:            Simple
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-mismi-core

--- a/mismi-sts/mismi-sts.cabal
+++ b/mismi-sts/mismi-sts.cabal
@@ -17,9 +17,9 @@ library
                      , ambiata-p
                      , ambiata-mismi-core
                      , ambiata-x-eithert
-                     , amazonka                        == 1.3.2.1
-                     , amazonka-core                   == 1.3.2
-                     , amazonka-sts                    == 1.3.2
+                     , amazonka                        == 1.3.4
+                     , amazonka-core                   == 1.3.4
+                     , amazonka-sts                    == 1.3.4
                      , bytestring                      == 0.10.*
                      , exceptions                      == 0.8.*
                      , http-client                     == 0.4.18.*


### PR DESCRIPTION
Specifically, the `ScheduleKeyDeletion` type isn't present in 1.3.2. @nhibberd mentioned I should hold off on this until the current suite changes is done, so just putting this up for build purposes.