### PR TITLE
Missed an amazonka version.

### DIFF
--- a/mismi-sqs/test/mismi-sqs-test.cabal
+++ b/mismi-sqs/test/mismi-sqs-test.cabal
@@ -6,8 +6,8 @@ build-type:            Simple
 library
   build-depends:
                        base                            >= 3          && < 5
-                     , amazonka                        == 1.3.6
-                     , amazonka-core                   == 1.3.6
+                     , amazonka                        >= 1.3.6      && < 1.5
+                     , amazonka-core                   >= 1.3.6      && < 1.5
                      , ambiata-disorder-core
                      , ambiata-disorder-corpus
                      , ambiata-mismi-core


### PR DESCRIPTION
They should all be version ranges rather than a hardcoded version.

There can be issues with the lenses amazonka exports and what P exposes, care needs to be taken to ensure you have the right hiding on import.