### PR TITLE
Re-export Env from Mismi.Environment

### DIFF
--- a/mismi-core/src/Mismi/Environment.hs
+++ b/mismi-core/src/Mismi/Environment.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 module Mismi.Environment (
-    Region (..)
+    Env
+  , Region (..)
   , RegionError (..)
   , Debugging (..)
   , getRegionFromEnv


### PR DESCRIPTION
Seems like an oversight that this isn't provided by default when you `import Mismi`, since it's needed for `runAWS`.

N.B. you can still get it from `Mismi.Amazonka`. This might cause some redundant import warnings in existing code, not sure how long it's been hidden.