### PR TITLE
Split out mismi-s3-core.

### DIFF
--- a/boris.toml
+++ b/boris.toml
@@ -12,12 +12,14 @@
     , ["master", "build", "dist-7-8", "-C", "mismi-emr"]
     , ["master", "build", "dist-7-8", "-C", "mismi-iam"]
     , ["master", "build", "dist-7-8", "-C", "mismi-rds"]
+    , ["master", "build", "dist-7-8", "-C", "mismi-s3-core"]
     , ["master", "build", "dist-7-8", "-C", "mismi-s3"]
     , ["master", "build", "dist-7-8", "-C", "mismi-sqs"]
     , ["master", "build", "dist-7-8", "-C", "mismi-sts"]
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 
@@ -32,12 +34,14 @@
     , ["master", "build", "dist-7-10", "-C", "mismi-emr"]
     , ["master", "build", "dist-7-10", "-C", "mismi-iam"]
     , ["master", "build", "dist-7-10", "-C", "mismi-rds"]
+    , ["master", "build", "dist-7-10", "-C", "mismi-s3-core"]
     , ["master", "build", "dist-7-10", "-C", "mismi-s3"]
     , ["master", "build", "dist-7-10", "-C", "mismi-sqs"]
     , ["master", "build", "dist-7-10", "-C", "mismi-sts"]
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 
@@ -52,12 +56,14 @@
     , ["master", "build", "dist-8-0", "-C", "mismi-emr"]
     , ["master", "build", "dist-8-0", "-C", "mismi-iam"]
     , ["master", "build", "dist-8-0", "-C", "mismi-rds"]
+    , ["master", "build", "dist-8-0", "-C", "mismi-s3-core"]
     , ["master", "build", "dist-8-0", "-C", "mismi-s3"]
     , ["master", "build", "dist-8-0", "-C", "mismi-sqs"]
     , ["master", "build", "dist-8-0", "-C", "mismi-sts"]
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 
@@ -73,12 +79,14 @@
     , ["master", "build", "branches-7-8", "-C", "mismi-iam"]
     , ["master", "build", "branches-7-8", "-C", "mismi-rds"]
     , ["master", "build", "branches-7-8", "-C", "mismi-s3"]
+    , ["master", "build", "branches-7-8", "-C", "mismi-s3-core"]
     , ["master", "build", "branches-7-8", "-C", "mismi-sqs"]
     , ["master", "build", "branches-7-8", "-C", "mismi-sts"]
 
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 
@@ -93,12 +101,14 @@
     , ["master", "build", "branches-7-10", "-C", "mismi-emr"]
     , ["master", "build", "branches-7-10", "-C", "mismi-iam"]
     , ["master", "build", "branches-7-10", "-C", "mismi-rds"]
+    , ["master", "build", "branches-7-10", "-C", "mismi-s3-core"]
     , ["master", "build", "branches-7-10", "-C", "mismi-s3"]
     , ["master", "build", "branches-7-10", "-C", "mismi-sqs"]
     , ["master", "build", "branches-7-10", "-C", "mismi-sts"]
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 
@@ -113,12 +123,14 @@
     , ["master", "build", "branches-8-0", "-C", "mismi-emr"]
     , ["master", "build", "branches-8-0", "-C", "mismi-iam"]
     , ["master", "build", "branches-8-0", "-C", "mismi-rds"]
+    , ["master", "build", "branches-8-0", "-C", "mismi-s3-core"]
     , ["master", "build", "branches-8-0", "-C", "mismi-s3"]
     , ["master", "build", "branches-8-0", "-C", "mismi-sqs"]
     , ["master", "build", "branches-8-0", "-C", "mismi-sts"]
 
     , ["bin/ci.cabal", "mismi-core"]
     , ["bin/ci.cabal", "mismi-ec2"]
+    , ["bin/ci.cabal", "mismi-s3-core"]
     , ["bin/ci.cabal", "mismi-s3"]
     ]
 

--- a/mismi-s3-core/.ghci
+++ b/mismi-s3-core/.ghci
@@ -1,0 +1,1 @@
+../framework/ghci

--- a/mismi-s3-core/LICENSE
+++ b/mismi-s3-core/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mismi-s3-core/mafia
+++ b/mismi-s3-core/mafia
@@ -1,0 +1,1 @@
+../framework/mafia

--- a/mismi-s3-core/master.toml
+++ b/mismi-s3-core/master.toml
@@ -1,0 +1,40 @@
+[master]
+  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20160603003512-3d86f6c/master-haskell-20160603003512-3d86f6c"
+  version = 1
+  sha1 = "4fd979c87b2dfd7d8909ae052f3aeb66939b4bc2"
+
+[build.dist]
+  GHC_VERSION="7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.dist-7-8]
+  GHC_VERSION = "7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.branches]
+  GHC_VERSION = "7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.branches-7-8]
+  GHC_VERSION = "7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.dist-7-10]
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
+  GHC_VERSION = "7.10.2"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.branches-7-10]
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
+  GHC_VERSION = "7.10.2"
+  CABAL_VERSION = "1.22.4.0"
+
+[build.dist-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"
+
+[build.branches-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"

--- a/mismi-s3-core/mismi-s3-core.cabal
+++ b/mismi-s3-core/mismi-s3-core.cabal
@@ -1,0 +1,44 @@
+name:                  ambiata-mismi-s3-core
+version:               0.0.1
+license:               Apache-2.0
+license-file:          LICENSE
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata
+synopsis:              AWS library
+category:              AWS
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           mismi-s3-core.
+
+library
+  build-depends:
+                       base                            >= 3          && < 6
+                     , ambiata-p
+                     , attoparsec                      >= 0.12       && < 0.14
+                     , text                            == 1.2.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+
+  exposed-modules:
+                       Mismi.S3.Core.Data
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  ghc-options:         -Wall -threaded -O2
+  hs-source-dirs:      test
+  build-depends:       base
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-mismi-s3-core
+                     , ambiata-p
+                     , attoparsec
+                     , text
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*

--- a/mismi-s3-core/src/Mismi/S3/Core/Data.hs
+++ b/mismi-s3-core/src/Mismi/S3/Core/Data.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+module Mismi.S3.Core.Data (
+    WriteMode (..)
+  , SyncMode (..)
+  , Bucket (..)
+  , Address (..)
+  , Key (..)
+  , ReadGrant (..)
+  , WriteResult (..)
+  , (//)
+  , combineKey
+  , dirname
+  , foldWriteMode
+  , foldSyncMode
+  , basename
+  , addressFromText
+  , addressToText
+  , removeCommonPrefix
+  , withKey
+  , s3Parser
+  ) where
+
+import           Data.Attoparsec.Text hiding (parse, Fail)
+import qualified Data.Attoparsec.Text as AT
+import qualified Data.Text as T
+import           Data.List (init, zipWith)
+import           Data.String
+
+import           P
+
+data WriteResult =
+    WriteOk
+  | WriteDestinationExists Address
+  deriving (Eq, Show)
+
+-- |
+-- Describes the semantics for destructive operation that may result in overwritten files.
+--
+data WriteMode =
+    Fail        -- ^ Fail rather than overwrite any data.
+  | Overwrite   -- ^ Overwrite existing data silently, i.e. we really want to do this.
+  deriving (Eq, Show)
+
+foldWriteMode :: a -> a -> WriteMode -> a
+foldWriteMode f o m = case m of
+  Fail -> f
+  Overwrite -> o
+
+data SyncMode =
+    FailSync
+  | OverwriteSync
+  | SkipSync
+  deriving (Eq, Show)
+
+foldSyncMode :: a -> a -> a -> SyncMode -> a
+foldSyncMode f o s m = case m of
+  FailSync -> f
+  OverwriteSync -> o
+  SkipSync -> s
+
+newtype Bucket =
+  Bucket {
+      unBucket :: Text
+    } deriving (Eq, Show, Ord)
+
+newtype Key =
+  Key {
+      unKey :: Text
+    } deriving (Eq, Show, Ord)
+
+data Address =
+  Address {
+      bucket :: Bucket
+    , key :: Key
+    } deriving (Eq, Ord)
+
+newtype ReadGrant =
+  ReadGrant {
+      readGrant :: Text
+    } deriving (Eq, Show)
+
+instance Show Address where
+  show (Address b k) =
+    "Address (" <> show b <> ") (" <> show k <> ")"
+
+(//) :: Key -> Key -> Key
+(//) =
+  combineKey
+
+combineKey :: Key -> Key -> Key
+combineKey (Key p1) (Key p2) =
+  if  "/" `T.isSuffixOf` p1 || p1 == "" || "/" `T.isPrefixOf` p2
+    then Key $ p1 <> p2
+    else Key $ p1 <> "/" <> p2
+
+withKey :: (Key -> Key) -> Address -> Address
+withKey f (Address b k) =
+  Address b $ f k
+
+dirname :: Key -> Key
+dirname =
+  Key . T.intercalate "/" . init . T.split (=='/') . unKey
+
+-- | Get the basename for a given key (eg. basename "/foo/bar" == "bar").
+--   Return 'Nothing' for the empty 'Key' _and_ when the name ends with a '/'.
+basename :: Key -> Maybe Text
+basename =
+  mfilter (not . T.null) . listToMaybe . reverse . T.split (== '/') . unKey
+
+-- prefix key
+removeCommonPrefix :: Address -> Address -> Maybe Key
+removeCommonPrefix prefix addr =
+  let dropMaybe :: String -> String -> Maybe Text
+      dropMaybe x y =
+        bool
+          Nothing
+          (Just . T.pack $ drop (length y) x)
+          (check x y)
+      check :: String -> String -> Bool
+      check x y = y == zipWith const x y
+  in
+  if bucket addr == bucket prefix
+     then
+       if unKey (key prefix) == ""
+          then
+            Just $ key addr
+          else
+            let bk = unKey (key prefix)
+                b = bool (bk <> "/") bk ("/" `T.isSuffixOf` bk)
+                pk = T.unpack b
+                kk = T.unpack (unKey $ key addr)
+            in
+              Key <$> dropMaybe kk pk
+     else
+       Nothing
+
+addressToText :: Address -> Text
+addressToText a =
+  "s3://" <> unBucket (bucket a) <> "/" <> unKey (key a)
+
+addressFromText :: Text -> Maybe Address
+addressFromText =
+  rightToMaybe . AT.parseOnly s3Parser
+
+s3Parser :: Parser Address
+s3Parser =
+  s3Parser' <|> s3Parser''
+
+s3Parser' :: Parser Address
+s3Parser' = do
+  _ <- string "s3://"
+  b <- manyTill anyChar (char '/')
+  k <- many anyChar
+  pure $ Address (Bucket . T.pack $ b) (Key . T.pack $ k)
+
+s3Parser'' :: Parser Address
+s3Parser'' = do
+  _ <- string "s3://"
+  b <- takeWhile (/= '/')
+  endOfInput
+  pure $ Address (Bucket b) (Key "")

--- a/mismi-s3-core/test/Test/Mismi/S3/Core/Arbitrary.hs
+++ b/mismi-s3-core/test/Test/Mismi/S3/Core/Arbitrary.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.Mismi.S3.Core.Arbitrary where
+
+import           Data.Text as T
+
+import           Disorder.Corpus
+
+import           Mismi.S3.Core.Data
+
+import           P
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+
+instance Arbitrary WriteMode where
+  arbitrary = elements [Fail, Overwrite]
+
+instance Arbitrary Bucket where
+  arbitrary = Bucket <$> elements southpark
+
+instance Arbitrary Address where
+  arbitrary = frequency [
+      (9, Address <$> arbitrary <*> arbitrary)
+    , (1, flip Address (Key "") <$> arbitrary)
+    ]
+
+instance Arbitrary Key where
+  -- The max length of S3 Paths is 1024 - and we append some of them in the tests
+  -- Unfortunately unicode characters aren't supported in the Haskell AWS library
+  -- https://github.com/ambiata/vee/issues/7
+  arbitrary =
+    let genPath = elements ["happy", "sad", ".", ":", "-"]
+        path = do
+          sep <- elements ["-", "=", "#", ""]
+          T.take 256 . T.intercalate "/" <$> listOf1 (T.intercalate sep <$> listOf1 genPath)
+    in (Key . append "tests/") <$> path

--- a/mismi-s3-core/test/Test/Mismi/S3/Core/Data.hs
+++ b/mismi-s3-core/test/Test/Mismi/S3/Core/Data.hs
@@ -1,20 +1,21 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Test.Mismi.S3.Data where
+module Test.Mismi.S3.Core.Data where
 
 import           Data.Text as T
 import           Data.List as L (sort)
 import           Disorder.Corpus
 
-import           Mismi.S3.Data
+import           Mismi.S3.Core.Data
 
 import           P
 
 import           System.IO
 
 import           Test.QuickCheck
-import           Test.Mismi.S3 ()
+import           Test.Mismi.S3.Core.Arbitrary ()
+
 
 prop_append :: Key -> Key -> Property
 prop_append p1 p2 =

--- a/mismi-s3-core/test/mismi-s3-core-test.cabal
+++ b/mismi-s3-core/test/mismi-s3-core-test.cabal
@@ -1,0 +1,19 @@
+name:                  ambiata-mismi-s3-core-test
+version:               0.0.1
+cabal-version:         >= 1.8
+build-type:            Simple
+
+library
+  build-depends:
+                       base                            >= 3          && < 6
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-mismi-s3-core
+                     , ambiata-p
+                     , attoparsec
+                     , text
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+
+  exposed-modules:
+                     Test.Mismi.S3.Core.Arbitrary

--- a/mismi-s3-core/test/test.hs
+++ b/mismi-s3-core/test/test.hs
@@ -1,0 +1,10 @@
+import           Disorder.Core.Main
+
+import qualified Test.Mismi.S3.Core.Data
+
+
+main :: IO ()
+main =
+  disorderMain [
+      Test.Mismi.S3.Core.Data.tests
+    ]

--- a/mismi-s3/mismi-s3.cabal
+++ b/mismi-s3/mismi-s3.cabal
@@ -15,6 +15,7 @@ library
   build-depends:
                        base                            >= 3          && < 6
                      , ambiata-mismi-core
+                     , ambiata-mismi-s3-core
                      , ambiata-p
                      , ambiata-x-conduit
                      , ambiata-x-eithert
@@ -76,6 +77,7 @@ executable s3
                      , exceptions
                      , ambiata-mismi-core
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
                      , ambiata-p
                      , ambiata-x-optparse
                      , ambiata-x-eithert
@@ -102,6 +104,8 @@ test-suite test
                      , ambiata-mismi-core
                      , ambiata-mismi-core-test
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
+                     , ambiata-mismi-s3-core-test
                      , ambiata-p
                      , ambiata-x-eithert
                      , conduit
@@ -137,6 +141,8 @@ test-suite test-io
                      , ambiata-mismi-core
                      , ambiata-mismi-core-test
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
+                     , ambiata-mismi-s3-core-test
                      , ambiata-p
                      , ambiata-x-eithert
                      , bytestring
@@ -174,6 +180,8 @@ test-suite test-reliability
                      , ambiata-mismi-core
                      , ambiata-mismi-core-test
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
+                     , ambiata-mismi-s3-core-test
                      , ambiata-p
                      , ambiata-x-eithert
                      , bytestring
@@ -219,6 +227,8 @@ benchmark bench
                      , ambiata-mismi-core
                      , ambiata-mismi-core-test
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
+                     , ambiata-mismi-s3-core-test
                      , ambiata-p
                      , ambiata-x-eithert
                      , criterion                       == 1.1.*

--- a/mismi-s3/src/Mismi/S3/Data.hs
+++ b/mismi-s3/src/Mismi/S3/Data.hs
@@ -41,16 +41,16 @@ module Mismi.S3.Data (
 
 import           Control.Exception.Base
 
-import           Data.Attoparsec.Text hiding (parse, Fail)
-import qualified Data.Attoparsec.Text as AT
 import qualified Data.Text as T
-import           Data.List (init, zipWith)
-import           Data.String
 import           Data.Typeable
 
 import           P
 
 import           Mismi (Error, renderError)
+                 -- Just for compatibility, would be good to not do
+                 -- this at some point but for now we import everything
+                 -- and keep current export list.
+import           Mismi.S3.Core.Data
 import           Network.AWS.S3 (ETag, ServerSideEncryption (..))
 
 import           System.FilePath (FilePath)
@@ -107,11 +107,6 @@ renderErrorType e = case e of
     "download"
   CopyError' ->
     "copy"
-
-data WriteResult =
-    WriteOk
-  | WriteDestinationExists Address
-  deriving (Eq, Show)
 
 data DownloadError =
     DownloadSourceMissing Address
@@ -191,139 +186,10 @@ renderSyncWorkerError w =
       "Copy failure during 'sync': " <> renderCopyError c
 
 
-
-
--- |
--- Describes the semantics for destructive operation that may result in overwritten files.
---
-data WriteMode =
-    Fail        -- ^ Fail rather than overwrite any data.
-  | Overwrite   -- ^ Overwrite existing data silently, i.e. we really want to do this.
-  deriving (Eq, Show)
-
-foldWriteMode :: a -> a -> WriteMode -> a
-foldWriteMode f o = \case
-  Fail -> f
-  Overwrite -> o
-
-data SyncMode =
-  FailSync
-  | OverwriteSync
-  | SkipSync
-  deriving (Eq, Show)
-
-foldSyncMode :: a -> a -> a -> SyncMode -> a
-foldSyncMode f o s = \case
-  FailSync -> f
-  OverwriteSync -> o
-  SkipSync -> s
-
-newtype Bucket = Bucket {
-    unBucket :: Text
-  } deriving (Eq, Show, Ord)
-
-data Address = Address {
-    bucket :: Bucket
-  , key :: Key
-  } deriving (Eq, Ord)
-
--- NOTE: This is not a "safe" data type, and makes no guarantee about what is _actually_ supported for S3
--- https://github.com/ambiata/mismi/issues/2
-newtype Key = Key {
-    unKey :: Text
-  } deriving (Eq, Show, Ord)
-
-newtype ReadGrant =
-  ReadGrant {
-      readGrant :: Text
-    } deriving (Eq, Show)
-
-instance Show Address where
-  show (Address b k) =
-    "Address (" <> show b <> ") (" <> show k <> ")"
-
 data Upload =
     UploadSingle
   | UploadMultipart Integer Integer
   deriving (Eq, Show)
-
-(//) :: Key -> Key -> Key
-(//) =
-  combineKey
-
-combineKey :: Key -> Key -> Key
-combineKey (Key p1) (Key p2) =
-  if  "/" `T.isSuffixOf` p1 || p1 == "" || "/" `T.isPrefixOf` p2
-    then Key $ p1 <> p2
-    else Key $ p1 <> "/" <> p2
-
-withKey :: (Key -> Key) -> Address -> Address
-withKey f (Address b k) =
-  Address b $ f k
-
-
-dirname :: Key -> Key
-dirname =
-  Key . T.intercalate "/" . init . T.split (=='/') . unKey
-
--- | Get the basename for a given key (eg. basename "/foo/bar" == "bar").
---   Return 'Nothing' for the empty 'Key' _and_ when the name ends with a '/'.
-basename :: Key -> Maybe Text
-basename =
-  mfilter (not . T.null) . listToMaybe . reverse . T.split (== '/') . unKey
-
--- prefix key
-removeCommonPrefix :: Address -> Address -> Maybe Key
-removeCommonPrefix prefix addr =
-  let dropMaybe :: String -> String -> Maybe Text
-      dropMaybe x y =
-        bool
-          Nothing
-          (Just . T.pack $ drop (length y) x)
-          (check x y)
-      check :: String -> String -> Bool
-      check x y = y == zipWith const x y
-  in
-  if bucket addr == bucket prefix
-     then
-       if unKey (key prefix) == ""
-          then
-            Just $ key addr
-          else
-            let bk = unKey (key prefix)
-                b = bool (bk <> "/") bk ("/" `T.isSuffixOf` bk)
-                pk = T.unpack b
-                kk = T.unpack (unKey $ key addr)
-            in
-              Key <$> dropMaybe kk pk
-     else
-       Nothing
-
-addressToText :: Address -> Text
-addressToText a =
-  "s3://" <> unBucket (bucket a) <> "/" <> unKey (key a)
-
-addressFromText :: Text -> Maybe Address
-addressFromText =
-  rightToMaybe . AT.parseOnly s3Parser
-
-s3Parser :: Parser Address
-s3Parser =
-  s3Parser' <|> s3Parser''
-
-s3Parser' :: Parser Address
-s3Parser' = do
-  _ <- string "s3://"
-  b <- manyTill anyChar (char '/')
-  k <- many anyChar
-  pure $ Address (Bucket . T.pack $ b) (Key . T.pack $ k)
-
-s3Parser'' :: Parser Address
-s3Parser'' = do
-  _ <- string "s3://"
-  b <- takeWhile (/= '/')
-  endOfInput
-  pure $ Address (Bucket b) (Key "")
 
 sse :: ServerSideEncryption
 sse =

--- a/mismi-s3/test/Test/Mismi/S3/Arbitrary.hs
+++ b/mismi-s3/test/Test/Mismi/S3/Arbitrary.hs
@@ -1,38 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Mismi.S3.Arbitrary where
 
-import           Data.Text as T
-
-import           Disorder.Corpus
-
-import           Mismi.S3.Data
-
-import           P
-
-import           Test.QuickCheck
-
-
-instance Arbitrary WriteMode where
-  arbitrary = elements [Fail, Overwrite]
-
-instance Arbitrary Bucket where
-  arbitrary = Bucket <$> elements southpark
-
-instance Arbitrary Address where
-  arbitrary = frequency [
-      (9, Address <$> arbitrary <*> arbitrary)
-    , (1, flip Address (Key "") <$> arbitrary)
-    ]
-
-instance Arbitrary Key where
-  -- The max length of S3 Paths is 1024 - and we append some of them in the tests
-  -- Unfortunately unicode characters aren't supported in the Haskell AWS library
-  -- https://github.com/ambiata/vee/issues/7
-  arbitrary =
-    let genPath = elements ["happy", "sad", ".", ":", "-"]
-        path = do
-          sep <- elements ["-", "=", "#", ""]
-          T.take 256 . T.intercalate "/" <$> listOf1 (T.intercalate sep <$> listOf1 genPath)
-    in (Key . append "tests/") <$> path
+-- For compatibility only
+import           Test.Mismi.S3.Core.Arbitrary ()

--- a/mismi-s3/test/mismi-s3-test.cabal
+++ b/mismi-s3/test/mismi-s3-test.cabal
@@ -14,6 +14,8 @@ library
                      , ambiata-mismi-core
                      , ambiata-mismi-core-test
                      , ambiata-mismi-s3
+                     , ambiata-mismi-s3-core
+                     , ambiata-mismi-s3-core-test
                      , ambiata-p
                      , ambiata-x-eithert
                      , ambiata-twine

--- a/mismi-s3/test/test.hs
+++ b/mismi-s3/test/test.hs
@@ -2,7 +2,6 @@ import           Disorder.Core.Main
 
 import qualified Test.Mismi.S3.Commands
 import qualified Test.Mismi.S3.Control
-import qualified Test.Mismi.S3.Data
 import qualified Test.Mismi.S3.Internal
 
 
@@ -11,6 +10,5 @@ main =
   disorderMain [
       Test.Mismi.S3.Commands.tests
     , Test.Mismi.S3.Control.tests
-    , Test.Mismi.S3.Data.tests
     , Test.Mismi.S3.Internal.tests
     ]


### PR DESCRIPTION
Bit fed up with dealing with amazonka just for `Bucket`, `Key` and `Address`.

This splits out a core set of data-types and parsers for these and a few other simple mismi-s3 types with minimal dependencies.

This has been done with a backwards compatible shim left in mismi-s3 so when upgrades projects won't know the difference until they want to know (and more importantly will allow a staggered roll-out).

@nhibberd 