### PR TITLE
Widen filepath bounds.

### DIFF
--- a/mismi-s3/mismi-s3.cabal
+++ b/mismi-s3/mismi-s3.cabal
@@ -31,7 +31,7 @@ library
                      , conduit-extra                   == 1.1.*
                      , directory                       == 1.2.*
                      , exceptions                      >= 0.6        && < 0.9
-                     , filepath                        == 1.4.*
+                     , filepath                        >= 1.3        && < 1.5
                      , http-client                     == 0.4.18.*
                      , http-conduit                    == 2.1.5.*
                      , http-types                      == 0.8.*

--- a/mismi-s3/test/mismi-s3-test.cabal
+++ b/mismi-s3/test/mismi-s3-test.cabal
@@ -23,7 +23,7 @@ library
                      , conduit                         == 1.2.*
                      , time                            >= 1.4        && < 1.6
                      , exceptions                      >= 0.6        && < 0.9
-                     , filepath                        == 1.4.*
+                     , filepath                        >= 1.3        && < 1.5
                      , http-client                     == 0.4.18.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.6


### PR DESCRIPTION
Does anyone know why the lower bound was bumped here? Causes a fair few problems with wai etc.. around things locked to 1.3.* (as well as most of our upstream depending on 1.3.*)?