### PR TITLE
Updating autoscaling instance protection

### DIFF
--- a/mismi-autoscaling/mismi-autoscaling.cabal
+++ b/mismi-autoscaling/mismi-autoscaling.cabal
@@ -50,9 +50,8 @@ test-suite test
   hs-source-dirs:      test
   build-depends:       base
                      , ambiata-disorder-core
-                     , ambiata-mismi-core
                      , ambiata-mismi-autoscaling
-                     , ambiata-mismi-autoscaling-core
+                     , ambiata-p
                      , QuickCheck                      >= 2.8.2      && < 2.9
                      , quickcheck-instances            == 0.3.*
 
@@ -74,6 +73,7 @@ test-suite test-io
                      , ambiata-p
                      , ambiata-twine
                      , ambiata-x-eithert
+                     , retry                           == 0.7.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.3.1      && < 0.6
                      , QuickCheck                      >= 2.8.2      && < 2.9

--- a/mismi-autoscaling/test/Test/IO/Mismi/Autoscaling/Commands.hs
+++ b/mismi-autoscaling/test/Test/IO/Mismi/Autoscaling/Commands.hs
@@ -128,14 +128,15 @@ prop_scale_in = once . testGroup $ \c g -> do
   r <- describeOrFail g
   let is = scalingInstanceId <$> groupResultInstances r
   lock <- retryX . runEitherT $ lockInstances g is
+  lock' <- retryX . runEitherT $ lockInstances g is
   locked <- describeOrFail g
   unlock <- retryX . runEitherT $ unlockInstances g is
   unlocked <- describeOrFail g
   let pro = fmap scalingInstanceProtected . groupResultInstances
   pure $
-    (length is, pro locked, pro unlocked, lock, unlock)
+    (length is, pro locked, pro unlocked, lock, lock', unlock)
     ===
-    (1, [ProtectedFromScaleIn], [NotProtectedFromScaleIn], Right (), Right ())
+    (1, [ProtectedFromScaleIn], [NotProtectedFromScaleIn], Right (), Right (), Right ())
 
 prop_update_min_max = once . testGroup $ \c g -> do
   let

--- a/mismi-autoscaling/test/Test/Mismi/Autoscaling/Data.hs
+++ b/mismi-autoscaling/test/Test/Mismi/Autoscaling/Data.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Mismi.Autoscaling.Data where
+
+import           Mismi.Autoscaling.Data
+
+import           P
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+prop_parse_protection_error = conjoin [
+    parseProtectionError "The instance i-ef2f5d40 is not part of Auto Scaling group stewed.27197.animal."
+      === InstanceProtectionNotFound
+  , parseProtectionError "The instance i-ef2f5d40 is not in InService or EnteringStandby or Standby."
+      === InstanceProtectionInvalidState
+  ]
+
+prop_parse_protection_error_unknown u =
+  parseProtectionError u === InstanceProtectionUnknownError u
+
+return []
+tests = $quickCheckAll

--- a/mismi-autoscaling/test/mismi-autoscaling-test.cabal
+++ b/mismi-autoscaling/test/mismi-autoscaling-test.cabal
@@ -18,6 +18,7 @@ library
                      , ambiata-p
                      , ambiata-twine
                      , ambiata-x-eithert
+                     , retry                           == 0.7.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.3.1      && < 0.6
                      , QuickCheck                      >= 2.7        && < 2.9

--- a/mismi-autoscaling/test/test.hs
+++ b/mismi-autoscaling/test/test.hs
@@ -1,7 +1,9 @@
 import           Disorder.Core.Main
 
+import qualified Test.Mismi.Autoscaling.Data
 
 main :: IO ()
 main =
   disorderMain [
+      Test.Mismi.Autoscaling.Data.tests
     ]

--- a/mismi-core/src/Mismi/Control.hs
+++ b/mismi-core/src/Mismi/Control.hs
@@ -168,13 +168,13 @@ onStatus_ r f m =
       Nothing ->
         throwM e
 
-handleServiceError :: (ServiceError -> Bool) -> a -> AWS a -> AWS a
+handleServiceError :: (ServiceError -> Bool) -> (ServiceError -> a) -> AWS a -> AWS a
 handleServiceError f pass action =
   action `catch` \(e :: Error) ->
     case e of
       ServiceError se ->
         if f se
-          then pure pass
+          then pure $ pass se
           else throwM e
       SerializeError _ ->
         throwM e


### PR DESCRIPTION
Removing low level retries from instance-protection as discussed @markhibberd /cc @charleso 