### PR TITLE
Restrict the version of connection

### DIFF
--- a/mismi-core/mismi-core.cabal
+++ b/mismi-core/mismi-core.cabal
@@ -22,6 +22,12 @@ library
                      , ambiata-x-exception
                      , bifunctors                      >= 4.2        && < 5.3
                      , bytestring                      == 0.10.*
+
+                     -- Verison 0.2.6 of the connection package switched from Handles
+                     -- to sockets which produced all kinds of odd effects. See
+                     -- https://github.com/erikd-ambiata/test-warp-wai/issues/1#issuecomment-244351172
+                     , connection                      == 0.2.5
+
                      -- FIX for conduit-extra https://github.com/snoyberg/conduit/pull/261
                      , conduit-extra                   == 1.1.11
                      , exceptions                      >= 0.6        && < 0.9


### PR DESCRIPTION
Verison 0.2.6 of the connection library switched from `Handle`s to
`Socket`s which resulted in a number of bizarre unintended side
effects like data leaking from TLS connections into HTTP responses.

Until 0.2.6 is fixed, we will lock connection to the previous
version.