### PR TITLE
Add support for s3 size --recursive --summary --iec --metric

### DIFF
--- a/mismi-cli/mismi-cli.cabal
+++ b/mismi-cli/mismi-cli.cabal
@@ -16,7 +16,6 @@ executable s3
   ghc-options:         -Wall -threaded -O2
   hs-source-dirs:      gen
   build-depends:       base                            >= 3          && < 5
-                     , exceptions
                      , ambiata-mismi-core
                      , ambiata-mismi-openssl
                      , ambiata-mismi-s3
@@ -24,15 +23,17 @@ executable s3
                      , ambiata-p
                      , ambiata-x-optparse
                      , ambiata-x-eithert
-                     , filepath
-                     , optparse-applicative            >= 0.11 && < 0.13
-                     , transformers
-                     , conduit
-                     , unix
-                     , text
-                     , resourcet
                      , bytestring                      == 0.10.*
+                     , conduit
+                     , containers                      == 0.5.*
+                     , exceptions
+                     , filepath
                      , lens                            >= 4.8        && < 4.15
+                     , optparse-applicative            >= 0.11 && < 0.13
+                     , resourcet
+                     , text
+                     , transformers
+                     , unix
 
 test-suite test-cli
   type:                exitcode-stdio-1.0

--- a/mismi-s3-core/mismi-s3-core.cabal
+++ b/mismi-s3-core/mismi-s3-core.cabal
@@ -15,6 +15,7 @@ library
   build-depends:
                        base                            >= 3          && < 6
                      , ambiata-p
+                     , ambiata-x-show
                      , attoparsec                      >= 0.12       && < 0.14
                      , text                            == 1.2.*
 

--- a/mismi-s3/src/Mismi/S3.hs
+++ b/mismi-s3/src/Mismi/S3.hs
@@ -3,5 +3,6 @@ module Mismi.S3 (
   ) where
 
 import           Mismi.Control as X
-import           Mismi.S3.Data as X
 import           Mismi.S3.Commands as X
+import           Mismi.S3.Core.Data as X
+import           Mismi.S3.Data as X

--- a/mismi-s3/test/Test/Reliability/Reliability.hs
+++ b/mismi-s3/test/Test/Reliability/Reliability.hs
@@ -36,11 +36,11 @@ testAWS' f = testAWS $ do
 testSize :: IO Int
 testSize = do
   view <- lookupEnv "TEST_RELIABILITY_SIZE"
-  let size = maybe 10 P.read view
-  pure size
+  let x = maybe 10 P.read view
+  pure x
 
 getMaxSuccess :: IO Int
 getMaxSuccess = do
   view <- lookupEnv "TEST_RELIABILITY_SUCCESS"
-  let size = maybe 5 P.read view
-  pure size
+  let x = maybe 5 P.read view
+  pure x


### PR DESCRIPTION
Some example usages:
```
$ s3 size --help
Usage: s3 size S3URI [-r|--recursive] [-s|--summary] ([-h|--iec] |
               [-m|--metric])
  Get the size of an address.

Available options:
  S3URI                    An s3 uri, i.e. s3://bucket/prefix/key
  -r,--recursive           Recursively list
  -s,--summary             Display only the combined total for a prefix.
  -h,--iec                 Human-readable output, using IEC unit prefixes, i.e.
                           1024^n
  -m,--metric              Human-readable output, using metric unit prefixes,
                           i.e. 1000^n
  -h,--help                Show this help text
```
```
$ s3 size s3://bucket/foo/part-00000
42114
```
```
$ s3 size --iec s3://bucket/foo/part-00000
 41 KiB
```
```
$ s3 size --metric s3://bucket/foo/part-00000
 42 kB
```
```
$ s3 size --recursive s3://bucket/foo
42114	s3://bucket/foo/part-00000
35122	s3://bucket/foo/part-00001
44855	s3://bucket/foo/part-00002
68891	s3://bucket/foo/part-00003
```
```
$ s3 size --recursive --iec s3://bucket/foo
 41 KiB  s3://bucket/foo/part-00000
 34 KiB  s3://bucket/foo/part-00001
 44 KiB  s3://bucket/foo/part-00002
 67 KiB  s3://bucket/foo/part-00003
```
```
$ s3 size --recursive --metric s3://bucket/foo
 42 kB  s3://bucket/foo/part-00000
 35 kB  s3://bucket/foo/part-00001
 45 kB  s3://bucket/foo/part-00002
 69 kB  s3://bucket/foo/part-00003
```
```
$ s3 size --recursive --summary s3://bucket/foo
179982	s3://bucket/foo
```
```
$ s3 size --recursive --summary --iec s3://bucket/foo
176 KiB  s3://bucket/foo
```
```
$ s3 size --recursive --summary --metric s3://bucket/foo
180 kB  s3://bucket/foo
```

! @nhibberd 