### PR TITLE
Fix s3 help usage

### DIFF
--- a/mismi-cli/main/s3.hs
+++ b/mismi-cli/main/s3.hs
@@ -286,7 +286,7 @@ optAppendFileName f k = fromMaybe f $ do
 
 mismi :: Force -> Parser (SafeCommand Command)
 mismi f =
-  safeCommand (commandP' f)
+  safeCommand (commandP' f <|> deprecatedCommandP')
 
 commandP' :: Force -> Parser Command
 commandP' f = subparser $
@@ -311,9 +311,6 @@ commandP' f = subparser $
   <> command' "write"
               "Write to an address."
               (Write <$> address' <*> text' <*> writeMode' f)
-  <> (internal <> command' "read"
-              "Read from an address. (Deprecated in favour of `s3 cat`.)"
-              (Read <$> address'))
   <> command' "cat"
               "Read raw data from an address and write it to stdout."
               (Cat <$> address')
@@ -326,6 +323,14 @@ commandP' f = subparser $
   <> command' "ls"
               "Stream a recursively list of objects on a prefix."
               (List <$> address' <*> recursive')
+
+deprecatedCommandP' :: Parser Command
+deprecatedCommandP' = subparser $
+  internal <> command'
+    "read"
+    "Read from an address. (Deprecated in favour of `s3 cat`.)"
+    (Read <$> address')
+
 
 recursive' :: Parser Recursive
 recursive' =

--- a/mismi-cli/test/cli/usage/expected
+++ b/mismi-cli/test/cli/usage/expected
@@ -1,0 +1,18 @@
+Usage: s3 ((-v|--version) | COMMAND)
+
+Available options:
+  -v,--version             Version information
+  -h,--help                Show this help text
+
+Available commands:
+  upload                   Upload a file to s3.
+  download                 Download a file from s3.
+  copy                     Copy a file from an S3 address to another S3 address.
+  move                     Move an S3 address to another S3 address
+  exists                   Check if an address exists.
+  delete                   Delete an address.
+  write                    Write to an address.
+  cat                      Read raw data from an address and write it to stdout.
+  size                     Get the size of an address.
+  sync                     Sync between two prefixes.
+  ls                       Stream a recursively list of objects on a prefix.

--- a/mismi-cli/test/cli/usage/run
+++ b/mismi-cli/test/cli/usage/run
@@ -1,0 +1,22 @@
+#!/bin/sh -eu
+
+. $(dirname $0)/../core/runner.sh
+
+banner usage
+############
+
+EXPECTED=$(dirname $0)/expected
+
+$MISMI --help > ${TEST}/usage
+
+if diff -q ${TEST}/usage ${EXPECTED}; then
+    echo "PASSED [usage]"
+else
+    echo "Test case [usage] failed:"
+    echo "======="
+    echo ""
+    diff ${TEST}/usage ${EXPECTED}
+    echo ""
+    echo "======="
+    exit_cleanup
+fi


### PR DESCRIPTION
https://github.com/ambiata/mismi/pull/354#issuecomment-283627179

Current:
```
 ./dist/build/s3/s3 --help
Usage: s3 (-v|--version)

Available options:
  -v,--version             Version information
  -h,--help                Show this help text
```

Change:
```
./dist/build/s3/s3 --help                                
Usage: s3 ((-v|--version) | COMMAND)

Available options:
  -v,--version             Version information
  -h,--help                Show this help text

Available commands:
  upload                   Upload a file to s3.
  download                 Download a file from s3.
  copy                     Copy a file from an S3 address to another S3 address.
  move                     Move an S3 address to another S3 address
  exists                   Check if an address exists.
  delete                   Delete an address.
  write                    Write to an address.
  cat                      Read raw data from an address and write it to stdout.
  size                     Get the size of an address.
  sync                     Sync between two prefixes.
  ls                       Stream a recursively list of objects on a prefix.
```

! @jystic @HuwCampbell @olorin 

Will add a usage test as well
/jury approved @jystic @HuwCampbell