### PR TITLE
Widen attoparsec bounds

### DIFF
--- a/mismi-s3/mismi-s3.cabal
+++ b/mismi-s3/mismi-s3.cabal
@@ -40,7 +40,7 @@ library
                      , semigroups                      >= 0.16       && < 0.19
                      , text                            == 1.2.*
                      , transformers                    >= 0.3.1      && < 0.6
-                     , attoparsec                      == 0.13.*
+                     , attoparsec                      >= 0.12       && < 0.14
                      , unix                            == 2.7.*
                      , async                           >= 2.0        && < 2.2
                      , retry                           == 0.7.*


### PR DESCRIPTION
! @charleso @tmcgilchrist @jystic 

https://github.com/ambiata/mismi/commit/2e4da9a6c2522a1e666a42287d6cc6fa09a5ea17#diff-eb16b6a1a71b145dc4efd20e9d2356b8L43

Don't see any problems with having the lower bounds at 0.12 unless I am missing something
/jury approved @charleso @jystic