### PR TITLE
Topic/fix download

### DIFF
--- a/mismi-s3/mismi-s3.cabal
+++ b/mismi-s3/mismi-s3.cabal
@@ -51,6 +51,7 @@ library
                      , unordered-containers            >= 0.2.5      && < 0.3
                      , uuid                            == 1.3.*
                      , mmorph                          == 1.0.*
+                     , lifted-base                     == 0.2.*
 
   ghc-options:
                        -Wall


### PR DESCRIPTION
I think this fixes https://github.com/ambiata/technology/issues/40

* Make the retry handler catch `IOExceptions` as well as `HttpException`.
* Add a timeout (of 10 minutes) to catch threads that make no progress and don't terminate.

As far as I am concerned, this uncovers two bugs in the software stack:

* http-client/conduit allowing an IOException to escape.
* Threads that make no progress and don't terminate (probably GHC RTS).

! @nhibberd @markhibberd  @olorin 
