### PR TITLE
Use concurrency of 20 instead of 5

### DIFF
--- a/mismi-s3/src/Mismi/S3/Commands.hs
+++ b/mismi-s3/src/Mismi/S3/Commands.hs
@@ -383,15 +383,16 @@ uploadWithMode m f a = do
     True ->
       lift $ uploadSingle f a
     False ->
-      -- Originally had a concurrency of 100 (instead of 5).
+      -- Originally had a concurrency of 100 (instead of 20).
       --
-      -- Based on the reasoning behind downloadWithMode choosing 5
-      -- as it's concurrency default.
+      -- Based on the reasoning behind downloadWithMode which resulted in a 5
+      -- as it's concurrency default. Testing showed that for upload 20 was a
+      -- better default.
       case s > 1024 * 1024 * 1024 of
         True ->
-          multipartUpload f a s (2 * chunk) 5
+          multipartUpload f a s (2 * chunk) 20
         False ->
-          multipartUpload f a s chunk 5
+          multipartUpload f a s chunk 20
 
 uploadSingle :: FilePath -> Address -> AWS ()
 uploadSingle file a = do


### PR DESCRIPTION
Testing showed that for upload 20 was a better default.

Merged the wrong damn branch :).

! @nhibberd @tmcgilchrist 
/jury approved @nhibberd