### PR TITLE
Sketch out syncWithMode'

### DIFF
--- a/mismi-s3-core/test/Test/Mismi/S3/Core/Arbitrary.hs
+++ b/mismi-s3-core/test/Test/Mismi/S3/Core/Arbitrary.hs
@@ -3,6 +3,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Mismi.S3.Core.Arbitrary where
 
+import qualified Data.List as DL
 import           Data.Text as T
 
 import           Disorder.Corpus
@@ -10,6 +11,8 @@ import           Disorder.Corpus
 import           Mismi.S3.Core.Data
 
 import           P
+
+import           System.IO (FilePath)
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
@@ -27,6 +30,12 @@ instance Arbitrary Address where
     , (1, flip Address (Key "") <$> arbitrary)
     ]
 
+instance Arbitrary Location where
+  arbitrary = oneof [
+      S3Location <$> arbitrary
+    , LocalLocation <$> genFilePath
+    ]
+
 instance Arbitrary Key where
   -- The max length of S3 Paths is 1024 - and we append some of them in the tests
   -- Unfortunately unicode characters aren't supported in the Haskell AWS library
@@ -37,3 +46,9 @@ instance Arbitrary Key where
           sep <- elements ["-", "=", "#", ""]
           T.take 256 . T.intercalate "/" <$> listOf1 (T.intercalate sep <$> listOf1 genPath)
     in (Key . append "tests/") <$> path
+
+
+genFilePath :: Gen FilePath
+genFilePath = do
+  len <- choose (1, 10)
+  DL.intercalate "/" . DL.take len <$> shuffle (simpsons <> southpark)

--- a/mismi-s3-core/test/Test/Mismi/S3/Core/Data.hs
+++ b/mismi-s3-core/test/Test/Mismi/S3/Core/Data.hs
@@ -36,6 +36,10 @@ prop_parse_bucket :: Bucket -> Property
 prop_parse_bucket b =
   addressFromText ("s3://" <> unBucket b) === Just (Address b (Key ""))
 
+prop_parse_location :: Location -> Property
+prop_parse_location loc =
+  locationFromText (locationToText loc) === loc
+
 prop_sorted :: [Address] -> Property
 prop_sorted addresses =
   fmap addressToText (L.sort addresses) === L.sort (fmap addressToText addresses)

--- a/mismi-s3/src/Mismi/S3/Commands.hs
+++ b/mismi-s3/src/Mismi/S3/Commands.hs
@@ -54,6 +54,7 @@ module Mismi.S3.Commands (
   , listRecursively'
   , sync
   , syncWithMode
+  , syncWithMode'
   , createMultipartUpload
   , grantReadAccess
   , hoistUploadError
@@ -707,3 +708,9 @@ worker input output mode env f = runEitherT . runAWST env SyncAws $ do
     (liftCopy $ copyWithMode Overwrite f out)
     (ifM (lift $ exists out) (right ()) cp)
     mode
+
+syncWithMode' :: SyncMode -> Location -> Location -> Int -> EitherT SyncError AWS ()
+syncWithMode' mode source dest fork =
+  case (source, dest) of
+    (S3Location src, S3Location dst) -> syncWithMode mode src dst fork
+    (_, _) -> left $ SyncLocation source dest

--- a/mismi-s3/src/Mismi/S3/Data.hs
+++ b/mismi-s3/src/Mismi/S3/Data.hs
@@ -191,12 +191,17 @@ renderUploadError e =
     MultipartUploadError a ->
       renderRunError a ((<>) "Multipart upload failed on a worker: " . renderError)
 
-newtype SyncError =
-  SyncError (RunError SyncWorkerError)
+data SyncError =
+    SyncError (RunError SyncWorkerError)
+  | SyncLocation Location Location
 
 renderSyncError :: SyncError -> Text
-renderSyncError (SyncError r) =
-  renderRunError r renderSyncWorkerError
+renderSyncError se =
+  case se of
+    SyncError r ->
+      renderRunError r renderSyncWorkerError
+    SyncLocation s d -> T.concat
+      ["Not able to syn between ", locationToText s, " and ", locationToText d, "."]
 
 data SyncWorkerError =
    SyncInvariant Address Address


### PR DESCRIPTION
On top of #372

The new function `syncWithMode'` is like its namesake (without the prime) but works with source and destination `Location`s which may either be an `S3` URI or a local `FilePath`. In currently only works for `S3` URI source and destination.

! @olorin @nhibberd @jystic 