### PR TITLE
Downgrade connection again due to leak

### DIFF
--- a/mismi-autoscaling/mismi-autoscaling.lock-7.10.2
+++ b/mismi-autoscaling/mismi-autoscaling.lock-7.10.2
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-autoscaling/mismi-autoscaling.lock-8.0.1
+++ b/mismi-autoscaling/mismi-autoscaling.lock-8.0.1
@@ -24,7 +24,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-autoscaling/test/mismi-autoscaling-test.lock-7.10.2
+++ b/mismi-autoscaling/test/mismi-autoscaling-test.lock-7.10.2
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-cli/mismi-cli.lock-7.10.2
+++ b/mismi-cli/mismi-cli.lock-7.10.2
@@ -24,7 +24,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-cli/mismi-cli.lock-8.0.1
+++ b/mismi-cli/mismi-cli.lock-8.0.1
@@ -25,7 +25,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-cloudwatch-logs/mismi-cloudwatch-logs.lock-7.10.2
+++ b/mismi-cloudwatch-logs/mismi-cloudwatch-logs.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-cloudwatch-logs/mismi-cloudwatch-logs.lock-8.0.1
+++ b/mismi-cloudwatch-logs/mismi-cloudwatch-logs.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-cloudwatch/mismi-cloudwatch.lock-7.10.2
+++ b/mismi-cloudwatch/mismi-cloudwatch.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-cloudwatch/mismi-cloudwatch.lock-8.0.1
+++ b/mismi-cloudwatch/mismi-cloudwatch.lock-8.0.1
@@ -20,7 +20,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-core/mismi-core.cabal
+++ b/mismi-core/mismi-core.cabal
@@ -22,7 +22,12 @@ library
                      , ambiata-x-exception
                      , bifunctors                      >= 4.2        && < 5.3
                      , bytestring                      == 0.10.*
-                     , connection                      == 0.2.8
+                     -- Verison 0.2.6 of the connection package switched from Handles
+                     -- to sockets which produced all kinds of odd effects. See
+                     -- https://github.com/erikd-ambiata/test-warp-wai/issues/1#issuecomment-244351172
+                     -- Version 0.2.8 has very rare connection leak issue that
+                     -- results in errors passing returned ByteStrings around to c libs.
+                     , connection                      == 0.2.5
                      , conduit-extra                   >= 1.1.15     && < 1.2
                      , exceptions                      >= 0.6        && < 0.9
                      , ini                             == 0.3.5

--- a/mismi-core/mismi-core.lock-7.10.2
+++ b/mismi-core/mismi-core.lock-7.10.2
@@ -21,7 +21,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-core/mismi-core.lock-8.0.1
+++ b/mismi-core/mismi-core.lock-8.0.1
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-core/test/mismi-core-test.lock-7.10.2
+++ b/mismi-core/test/mismi-core-test.lock-7.10.2
@@ -21,7 +21,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-dynamodb/mismi-dynamodb.lock-7.10.2
+++ b/mismi-dynamodb/mismi-dynamodb.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-ec2/mismi-ec2.lock-7.10.2
+++ b/mismi-ec2/mismi-ec2.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-ec2/mismi-ec2.lock-8.0.1
+++ b/mismi-ec2/mismi-ec2.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-elb/mismi-elb.lock-7.10.2
+++ b/mismi-elb/mismi-elb.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-elb/mismi-elb.lock-8.0.1
+++ b/mismi-elb/mismi-elb.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-emr/mismi-emr.lock-7.10.2
+++ b/mismi-emr/mismi-emr.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-emr/mismi-emr.lock-8.0.1
+++ b/mismi-emr/mismi-emr.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-iam/mismi-iam.lock-7.10.2
+++ b/mismi-iam/mismi-iam.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-iam/mismi-iam.lock-8.0.1
+++ b/mismi-iam/mismi-iam.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-openssl/mismi-openssl.lock-7.10.2
+++ b/mismi-openssl/mismi-openssl.lock-7.10.2
@@ -21,7 +21,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-openssl/mismi-openssl.lock-8.0.1
+++ b/mismi-openssl/mismi-openssl.lock-8.0.1
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-rds/mismi-rds.lock-7.10.2
+++ b/mismi-rds/mismi-rds.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-rds/mismi-rds.lock-8.0.1
+++ b/mismi-rds/mismi-rds.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-s3/mismi-s3.lock-7.10.2
+++ b/mismi-s3/mismi-s3.lock-7.10.2
@@ -28,7 +28,7 @@ code-page == 0.1.3
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 criterion == 1.1.4.0

--- a/mismi-s3/mismi-s3.lock-8.0.1
+++ b/mismi-s3/mismi-s3.lock-8.0.1
@@ -29,7 +29,7 @@ code-page == 0.1.3
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 criterion == 1.1.4.0

--- a/mismi-s3/test/mismi-s3-test.lock-7.10.2
+++ b/mismi-s3/test/mismi-s3-test.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-sqs/mismi-sqs.lock-7.10.2
+++ b/mismi-sqs/mismi-sqs.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-sqs/mismi-sqs.lock-8.0.1
+++ b/mismi-sqs/mismi-sqs.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-sqs/test/mismi-sqs-test.lock-7.10.2
+++ b/mismi-sqs/test/mismi-sqs-test.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptohash-md5 == 0.11.100.1

--- a/mismi-sts/mismi-sts.lock-7.10.2
+++ b/mismi-sts/mismi-sts.lock-7.10.2
@@ -22,7 +22,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22

--- a/mismi-sts/mismi-sts.lock-8.0.1
+++ b/mismi-sts/mismi-sts.lock-8.0.1
@@ -23,7 +23,7 @@ cereal == 0.5.4.0
 comonad == 5
 conduit == 1.2.9.1
 conduit-extra == 1.1.15
-connection == 0.2.8
+connection == 0.2.5
 contravariant == 1.4
 cookie == 0.4.2.1
 cryptonite == 0.22


### PR DESCRIPTION
! @nhibberd @ktonga 

This was causing the broken test upstream. I can't see a bug report on [connection](https://github.com/vincenthz/hs-connection) which I might try to create later if I can, but for now locking connection back down to avoid other errors (fortunately this was caught in a test).
/jury approved @olorin @ktonga